### PR TITLE
Task 2.1: Extract tester prompt to defaults/prompts/tester/write-tests.md

### DIFF
--- a/defaults/agents.toml
+++ b/defaults/agents.toml
@@ -1,0 +1,13 @@
+[conventions]
+# Target repos override this section to declare their language-specific conventions.
+# e.g. primary_language, test_command, test_runner, test_file_pattern, test_file_extension
+
+[agents.tester]
+model = "claude-sonnet-4-6"
+tools = ["Read", "Edit", "Bash"]
+identity = """
+You are a test-writing agent. You write comprehensive tests that follow TDD principles.
+Read existing tests first to understand patterns and conventions before writing new ones.
+"""
+tasks = ["write-tests"]
+prompt_dir = "prompts/tester"

--- a/defaults/prompts/tester/write-tests.md
+++ b/defaults/prompts/tester/write-tests.md
@@ -1,0 +1,19 @@
+You are a test-writing agent.
+
+Write comprehensive tests for this GitHub issue, following TDD principles.
+
+Issue #{{issue_number}}:
+{{issue_description}}
+
+Instructions:
+- Read the existing test directories first to understand the patterns and conventions.
+- Decide the correct test file path based on what is being tested, following the `{{test_file_pattern}}` convention.
+- Use `{{test_runner}}` to run the tests.
+- Test both happy paths and edge/error cases.
+- Each test must be independent.
+- Write the test file to disk at the correct path using the Edit tool.
+
+<!-- ORCHESTRATOR OUTPUT CONTRACT — DO NOT MODIFY -->
+
+After writing, output exactly one line in this format:
+  TEST_FILE: <relative/path/to/test/file.{{test_file_extension}}>


### PR DESCRIPTION
Closes #11

Extracts `PROMPT_TEMPLATE` from `agents/test_agent.py` into `defaults/prompts/tester/write-tests.md` with generic language, double-brace variable syntax, and output-contract marker. Registers the tester agent in `defaults/agents.toml`.

## Acceptance criteria
- ✅ File exists at `defaults/prompts/tester/write-tests.md`
- ✅ No Spades/node:test/.test.js references
- ✅ Output-contract marker present

Generated with [Claude Code](https://claude.ai/code)