### PR TITLE
Task 1.2: Add OutputContractError and BaseAgent

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -45,6 +45,27 @@ class TransientError(Exception):
     pass
 
 
+class OutputContractError(Exception):
+    """Raised when an agent's output does not satisfy the expected output contract."""
+
+    def __init__(self, agent: str, task: str, expected: str, got_preview: str):
+        self.agent = agent
+        self.task = task
+        self.expected = expected
+        self.got_preview = got_preview
+        super().__init__(
+            f"[{agent}/{task}] Output contract violation — "
+            f"expected: {expected!r} — got: {got_preview!r}"
+        )
+
+
+class BaseAgent:
+    """Base class for orchestrator agents. Provides default output parsing."""
+
+    def parse_response(self, text: str) -> dict:
+        return {"response": text}
+
+
 def run_claude(prompt: str, allowed_tools: str = "Read,Edit,Bash", cwd: str = None, model: str = None) -> str:
     """
     Run `claude -p` non-interactively and return the text response.


### PR DESCRIPTION
Closes #5

Adds `OutputContractError` exception and `BaseAgent` class to `agents/base_agent.py`.

## Acceptance criteria
- ✅ `from agents.base_agent import OutputContractError, BaseAgent` works
- ✅ `OutputContractError(agent="tester", task="write-tests", expected="TEST_FILE: line", got_preview="...")` produces human-readable `str()`
- ✅ `BaseAgent().parse_response("hello")` returns `{"response": "hello"}`
- ✅ No behavioral change to existing agents

Generated with [Claude Code](https://claude.ai/code)