### PR TITLE
Task 1.6: Implement variable interpolation in orchestrator/loader.py

### DIFF
--- a/orchestrator/loader.py
+++ b/orchestrator/loader.py
@@ -176,10 +176,13 @@ def compose_prompt(
         parts.append(OUTPUT_CONTRACT_MARKER)
         parts.append(default_post.strip())
 
-    # 5. Runtime context
+    variables = {**registry.get("conventions", {}), **context}
+    interpolated = interpolate("\n\n".join(parts), variables, prompt_filename=str(default_task_file))
+
+    # 5. Runtime context — appended AFTER interpolation so user-supplied values
+    # are never scanned for {{placeholder}} patterns.
     if context:
         context_lines = "\n".join(f"{k}: {v}" for k, v in context.items())
-        parts.append(f"## Runtime Context\n\n{context_lines}")
+        return f"{interpolated}\n\n## Runtime Context\n\n{context_lines}"
 
-    variables = {**registry.get("conventions", {}), **context}
-    return interpolate("\n\n".join(parts), variables, prompt_filename=str(default_task_file))
+    return interpolated

--- a/orchestrator/loader.py
+++ b/orchestrator/loader.py
@@ -91,6 +91,18 @@ def _extract_agents_md_sections(content: str, agent: str) -> str:
     return "\n\n".join(parts)
 
 
+def interpolate(text: str, variables: dict, prompt_filename: str | None = None) -> str:
+    """Substitute {{variable}} placeholders with values from variables."""
+    def _replace(match: re.Match) -> str:
+        name = match.group(1)
+        if name not in variables:
+            suffix = f" ({prompt_filename})" if prompt_filename else ""
+            raise ValueError(f"Undefined variable {{{{{name}}}}}{suffix} in prompt")
+        return str(variables[name])
+
+    return re.sub(r"\{\{(\w+)\}\}", _replace, text)
+
+
 def compose_prompt(
     agent: str,
     task: str,
@@ -169,4 +181,5 @@ def compose_prompt(
         context_lines = "\n".join(f"{k}: {v}" for k, v in context.items())
         parts.append(f"## Runtime Context\n\n{context_lines}")
 
-    return "\n\n".join(parts)
+    variables = {**registry.get("conventions", {}), **context}
+    return interpolate("\n\n".join(parts), variables, prompt_filename=str(default_task_file))

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2,7 +2,7 @@
 import pytest
 from pathlib import Path
 
-from orchestrator.loader import load_registry, compose_prompt, OUTPUT_CONTRACT_MARKER
+from orchestrator.loader import load_registry, compose_prompt, interpolate, OUTPUT_CONTRACT_MARKER
 
 
 def _make_defaults(root: Path, agents_toml_content: str = "") -> None:
@@ -339,3 +339,64 @@ class TestComposePromptAgentsMdCascade:
 
         assert "Shared rules." in result
         assert "Coder-only rules." not in result
+
+
+# ---------------------------------------------------------------------------
+# interpolate tests (Task 1.6)
+# ---------------------------------------------------------------------------
+
+class TestInterpolate:
+    def test_substitutes_double_brace_variable(self):
+        assert interpolate("run {{test_command}}", {"test_command": "pytest"}) == "run pytest"
+
+    def test_raises_value_error_naming_missing_variable(self):
+        with pytest.raises(ValueError, match="missing"):
+            interpolate("hi {{missing}}", {})
+
+    def test_single_braces_pass_through_unchanged(self):
+        text = '{"key": "value"}'
+        assert interpolate(text, {}) == text
+
+    def test_multiple_variables_all_substituted(self):
+        result = interpolate("{{a}} and {{b}}", {"a": "foo", "b": "bar"})
+        assert result == "foo and bar"
+
+    def test_prompt_filename_included_in_error_message(self):
+        with pytest.raises(ValueError, match="myfile.md"):
+            interpolate("{{missing}}", {}, prompt_filename="myfile.md")
+
+    def test_no_placeholders_returns_text_unchanged(self):
+        text = "nothing to replace here"
+        assert interpolate(text, {}) == text
+
+
+class TestComposePromptInterpolation:
+    def test_conventions_substituted_into_prompt(self, tmp_path):
+        target = tmp_path / "target"
+        target.mkdir()
+        _make_defaults(tmp_path, "[conventions]\n")
+        registry = {
+            "agents": {"tester": {"identity": ""}},
+            "conventions": {"test_command": "pytest"},
+        }
+        _make_default_task(tmp_path, "tester", "write-tests", "Run {{test_command}} to test.")
+
+        result = compose_prompt("tester", "write-tests", {}, registry, tmp_path, target)
+
+        assert "Run pytest to test." in result
+
+    def test_explicit_context_overrides_conventions(self, tmp_path):
+        target = tmp_path / "target"
+        target.mkdir()
+        _make_defaults(tmp_path, "[conventions]\n")
+        registry = {
+            "agents": {"tester": {"identity": ""}},
+            "conventions": {"test_command": "jest"},
+        }
+        _make_default_task(tmp_path, "tester", "write-tests", "Run {{test_command}} to test.")
+
+        result = compose_prompt(
+            "tester", "write-tests", {"test_command": "pytest"}, registry, tmp_path, target
+        )
+
+        assert "Run pytest to test." in result

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -400,3 +400,22 @@ class TestComposePromptInterpolation:
         )
 
         assert "Run pytest to test." in result
+
+    def test_context_value_with_double_brace_pattern_does_not_crash(self, tmp_path):
+        """Context values containing {{word}} must not be passed through interpolate."""
+        target = tmp_path / "target"
+        target.mkdir()
+        _make_defaults(tmp_path, "[conventions]\n")
+        _make_default_task(tmp_path, "tester", "write-tests", "Body.")
+
+        result = compose_prompt(
+            "tester",
+            "write-tests",
+            {"issue_title": "Implement {{variable}} interpolation"},
+            _registry(),
+            tmp_path,
+            target,
+        )
+
+        assert "{{variable}}" in result
+        assert "Runtime Context" in result


### PR DESCRIPTION
Closes #9

Adds `interpolate(text, variables, prompt_filename=None)` to `orchestrator/loader.py` using a regex to substitute `{{variable}}` placeholders. Undefined variables raise `ValueError`. Single braces pass through unchanged.

Wires `interpolate` into `compose_prompt`: registry conventions are merged into the variable namespace first, then explicit context overrides.

## Acceptance criteria

- ✅ `interpolate("run {{test_command}}", {"test_command": "pytest"})` → `"run pytest"`
- ✅ `interpolate("hi {{missing}}", {})` raises `ValueError` naming `missing`
- ✅ Literal single braces pass through unchanged

Generated with [Claude Code](https://claude.ai/code)