### PR TITLE
Task 2.1: Extract tester prompt to defaults/prompts/tester/write-tests.md

### DIFF
--- a/defaults/agents.toml
+++ b/defaults/agents.toml
@@ -1,3 +1,9 @@
 [conventions]
 # Orchestrator-shipped defaults. Target repos override this by providing their own
 # root-level agents.toml — see docs/orchestrator-refactor-prd.md §3 for merge rules.
+
+[agents.tester]
+identity = "You are a test-writing agent that produces well-structured, independent tests following TDD principles."
+model = "claude-sonnet-4-6"
+tools = ["Read", "Edit", "Bash"]
+tasks = ["write-tests"]

--- a/defaults/prompts/tester/write-tests.md
+++ b/defaults/prompts/tester/write-tests.md
@@ -1,0 +1,19 @@
+You are a test-writing agent.
+
+Write comprehensive tests for this GitHub issue, following TDD principles.
+
+Issue #{{issue_number}}:
+{{issue_description}}
+
+Instructions:
+- Read the existing test directories first to understand the patterns and conventions.
+- Decide the correct test file path following the project's `{{test_file_pattern}}` convention.
+- Use `{{test_runner}}` to write tests.
+- Test both happy paths and edge/error cases.
+- Each test must be independent.
+- Write the test file to disk at the correct path using the Edit tool.
+
+<!-- ORCHESTRATOR OUTPUT CONTRACT — DO NOT MODIFY -->
+
+After writing, output exactly one line in this format:
+  TEST_FILE: <relative/path/to/test/file.{{test_file_extension}}>


### PR DESCRIPTION
Closes #11

Extracts `PROMPT_TEMPLATE` from `agents/test_agent.py` into `defaults/prompts/tester/write-tests.md` with generic language, double-brace variable syntax, and output-contract marker. Registers the tester agent in `defaults/agents.toml`.

## Acceptance criteria
- ✅ File exists at `defaults/prompts/tester/write-tests.md`
- ✅ No Spades/node:test/.test.js references
- ✅ Output-contract marker present

Generated with [Claude Code](https://claude.ai/code)