### PR TITLE
Task 3.1: Migrate documentation_agent → docs-writer

### DIFF
--- a/agents/documentation_agent.py
+++ b/agents/documentation_agent.py
@@ -1,6 +1,15 @@
 import subprocess
+from pathlib import Path
 
-from agents.base_agent import run_claude, RateLimitError, PromptTooLongError, TransientError, REPO_DIR  # noqa: F401
+from agents.base_agent import (
+    BaseAgent, OutputContractError, run_claude,
+    RateLimitError, PromptTooLongError, TransientError, REPO_DIR  # noqa: F401
+)
+from orchestrator.loader import compose_prompt, load_registry
+
+
+_ORCHESTRATOR_ROOT = Path(__file__).parent.parent
+_TARGET_ROOT = Path(REPO_DIR)
 
 
 def run_git(args: list[str]):
@@ -15,30 +24,28 @@ def run_git(args: list[str]):
     return result.stdout.strip()
 
 
-PROMPT_TEMPLATE = """\
-You are a documentation agent for the Spades Online card game.
+class DocumentationAgent(BaseAgent):
+    def parse_response(self, text: str) -> dict:
+        if text.strip() == "NO_CHANGES":
+            return {"files_updated": []}
 
-Review the following code changes and update any documentation files that need to reflect them.
+        files_updated = []
+        for line in text.splitlines():
+            if line.startswith("UPDATED:"):
+                path = line[len("UPDATED:"):].strip()
+                if path:
+                    files_updated.append(path)
 
-Code changes (git diff --stat):
-{code_changes}
+        if files_updated:
+            return {"files_updated": files_updated}
 
-Documentation files to consider updating:
-- README.md — if new features, setup steps, or environment variables changed
-- docs/api.md — if HTTP routes were added, removed, or changed
-- docs/websocket.md — if WebSocket events were added, removed, or changed
+        raise OutputContractError(
+            agent="docs-writer",
+            task="document",
+            expected="NO_CHANGES or one or more UPDATED: <path> lines",
+            got_preview=text[:200],
+        )
 
-Instructions:
-- Read each documentation file first to understand its current state.
-- Only edit files that genuinely need updating — don't touch unaffected docs.
-- Write the full updated content of any file you change using the Edit tool.
-- If no documentation changes are needed, output exactly: NO_CHANGES
-- Otherwise, after writing all files, output exactly one line per file changed:
-  UPDATED: <relative/path/to/file.md>
-"""
-
-
-class DocumentationAgent:
     async def run(self, context: dict) -> dict:
         issue_number = context.get("issue_number")
         code_changes = context.get("code_changes", "")
@@ -50,23 +57,19 @@ class DocumentationAgent:
 
         print(f"[Docs] Checking documentation for issue #{issue_number}...")
 
-        prompt = PROMPT_TEMPLATE.format(code_changes=code_changes)
+        registry = load_registry(_ORCHESTRATOR_ROOT, _TARGET_ROOT)
+        prompt = compose_prompt(
+            "docs-writer", "document", context, registry, _ORCHESTRATOR_ROOT, _TARGET_ROOT
+        )
 
         # Claude Code runs in REPO_DIR so it can read and write doc files directly
         response = run_claude(prompt, allowed_tools="Read,Edit,Bash", model="claude-sonnet-4-6")
 
-        if response.strip() == "NO_CHANGES":
-            print("[Docs] No documentation changes needed.")
-            return {"agent": "documentation", "issue_number": issue_number, "files_updated": []}
-
-        # Parse UPDATED: lines to know which files were changed
-        files_updated = []
-        for line in response.splitlines():
-            if line.startswith("UPDATED:"):
-                files_updated.append(line[len("UPDATED:"):].strip())
+        parsed = self.parse_response(response)
+        files_updated = parsed["files_updated"]
 
         if not files_updated:
-            print("[Docs] No UPDATED lines found — assuming no changes.")
+            print("[Docs] No documentation changes needed.")
             return {"agent": "documentation", "issue_number": issue_number, "files_updated": []}
 
         for f in files_updated:

--- a/defaults/agents.toml
+++ b/defaults/agents.toml
@@ -7,3 +7,9 @@ identity = "You are a test-writing agent that produces well-structured, independ
 model = "claude-sonnet-4-6"
 tools = ["Read", "Edit", "Bash"]
 tasks = ["write-tests"]
+
+[agents."docs-writer"]
+identity = "You are a documentation agent that reviews code changes and keeps project documentation up to date."
+model = "claude-sonnet-4-6"
+tools = ["Read", "Edit", "Bash"]
+tasks = ["document"]

--- a/defaults/prompts/docs-writer/document.md
+++ b/defaults/prompts/docs-writer/document.md
@@ -1,0 +1,19 @@
+You are a documentation agent.
+
+Review the following code changes and update any documentation files that need to reflect them.
+
+Code changes (git diff --stat):
+{{code_changes}}
+
+Instructions:
+- Identify the project's documentation files (README.md, docs/, and similar).
+- Read each relevant documentation file to understand its current state.
+- Only edit files that genuinely need updating — don't touch unaffected docs.
+- Write the full updated content of any file you change using the Edit tool.
+
+<!-- ORCHESTRATOR OUTPUT CONTRACT — DO NOT MODIFY -->
+
+After completing all edits, output one of the following:
+- If no documentation changes are needed, output exactly: NO_CHANGES
+- Otherwise, output exactly one line per file changed:
+  UPDATED: <relative/path/to/file.md>

--- a/tests/test_documentation_agent.py
+++ b/tests/test_documentation_agent.py
@@ -1,0 +1,59 @@
+"""Unit tests for DocumentationAgent.parse_response."""
+import pytest
+from agents.documentation_agent import DocumentationAgent
+from agents.base_agent import OutputContractError
+
+
+class TestParseResponse:
+    def test_returns_empty_list_on_no_changes(self):
+        agent = DocumentationAgent()
+        result = agent.parse_response("NO_CHANGES")
+        assert result["files_updated"] == []
+
+    def test_strips_whitespace_around_no_changes(self):
+        agent = DocumentationAgent()
+        result = agent.parse_response("  NO_CHANGES  ")
+        assert result["files_updated"] == []
+
+    def test_returns_single_updated_file(self):
+        agent = DocumentationAgent()
+        result = agent.parse_response("Some preamble\nUPDATED: README.md\n")
+        assert result["files_updated"] == ["README.md"]
+
+    def test_returns_multiple_updated_files(self):
+        agent = DocumentationAgent()
+        result = agent.parse_response("UPDATED: README.md\nUPDATED: docs/guide.md\n")
+        assert result["files_updated"] == ["README.md", "docs/guide.md"]
+
+    def test_strips_whitespace_from_updated_path(self):
+        agent = DocumentationAgent()
+        result = agent.parse_response("UPDATED:   docs/api.md   ")
+        assert result["files_updated"] == ["docs/api.md"]
+
+    def test_raises_output_contract_error_on_missing_sentinel(self):
+        agent = DocumentationAgent()
+        with pytest.raises(OutputContractError) as exc_info:
+            agent.parse_response("No marker here at all.")
+        err = exc_info.value
+        assert err.agent == "docs-writer"
+        assert err.task == "document"
+        assert "NO_CHANGES" in err.expected
+        assert "UPDATED:" in err.expected
+
+    def test_raises_output_contract_error_on_empty_response(self):
+        agent = DocumentationAgent()
+        with pytest.raises(OutputContractError) as exc_info:
+            agent.parse_response("")
+        assert exc_info.value.got_preview == ""
+
+    def test_raises_output_contract_error_when_updated_path_is_empty(self):
+        agent = DocumentationAgent()
+        with pytest.raises(OutputContractError):
+            agent.parse_response("UPDATED:   \nOther content")
+
+    def test_got_preview_truncated_to_200_chars(self):
+        agent = DocumentationAgent()
+        long_text = "x" * 300
+        with pytest.raises(OutputContractError) as exc_info:
+            agent.parse_response(long_text)
+        assert len(exc_info.value.got_preview) == 200


### PR DESCRIPTION
Closes #14

Migrates `documentation_agent` to follow the `docs-writer` pattern:

- Extracts `PROMPT_TEMPLATE` to `defaults/prompts/docs-writer/document.md` (target-agnostic, no Spades file references)
- Registers `docs-writer` in `defaults/agents.toml` with `tasks = ["document"]`
- `DocumentationAgent` now inherits `BaseAgent`, uses `compose_prompt`, and has `parse_response`
- 9 unit tests added for `parse_response`

## Acceptance criteria
- ✅ `grep "PROMPT_TEMPLATE\|api\.md\|websocket\.md" agents/documentation_agent.py` returns nothing
- ⏳ End-to-end Spades run — requires human validation

Generated with [Claude Code](https://claude.ai/code)