### PR TITLE
fix: _extract_json false-positive from JS template literal braces

### DIFF
--- a/agents/reviewer_agent.py
+++ b/agents/reviewer_agent.py
@@ -157,14 +157,19 @@ class ReviewerAgent:
         except json.JSONDecodeError:
             pass
 
-        # Strategy 3: find the first { and last } and extract that substring
-        start = raw.find("{")
-        end = raw.rfind("}") + 1
-        if start != -1 and end > start:
-            try:
-                return json.loads(raw[start:end])
-            except json.JSONDecodeError:
-                pass
+        # Strategy 3: scan for the first parseable JSON object in the string.
+        # Uses raw_decode to avoid false positives from { in code snippets
+        # (e.g. JS template literals like `${variable}`) that would cause
+        # find/rfind substring extraction to grab the wrong range.
+        decoder = json.JSONDecoder()
+        for text in (raw, clean):
+            for i, ch in enumerate(text):
+                if ch == '{':
+                    try:
+                        obj, _ = decoder.raw_decode(text, i)
+                        return obj
+                    except json.JSONDecodeError:
+                        continue
 
         print("[Reviewer] Warning: could not parse JSON response, treating as no findings")
         return {"findings": [], "summary": raw[:200]}

--- a/tests/test_reviewer_agent.py
+++ b/tests/test_reviewer_agent.py
@@ -1,0 +1,63 @@
+"""Unit tests for ReviewerAgent._extract_json."""
+from agents.reviewer_agent import ReviewerAgent
+
+
+VALID_REVIEW = {
+    "findings": [
+        {
+            "severity": "HIGH",
+            "effort": "low",
+            "fix_inline": False,
+            "title": "Missing null check",
+            "body": "foo can be null",
+            "file": "src/foo.js",
+            "line": 10,
+        }
+    ],
+    "summary": "One high finding.",
+}
+
+VALID_JSON = '{"findings": [{"severity": "HIGH", "effort": "low", "fix_inline": false, "title": "Missing null check", "body": "foo can be null", "file": "src/foo.js", "line": 10}], "summary": "One high finding."}'
+
+
+class TestExtractJson:
+    def test_parses_plain_json_response(self):
+        agent = ReviewerAgent()
+        result = agent._extract_json(VALID_JSON)
+        assert result["summary"] == "One high finding."
+        assert len(result["findings"]) == 1
+
+    def test_parses_json_wrapped_in_markdown_fences(self):
+        agent = ReviewerAgent()
+        raw = f"```json\n{VALID_JSON}\n```"
+        result = agent._extract_json(raw)
+        assert result["summary"] == "One high finding."
+
+    def test_parses_json_preceded_by_prose_with_template_literal_braces(self):
+        # Regression test: prose containing JS template literals like `${active}`
+        # caused the old find("{") strategy to grab the wrong position, making
+        # all JSON extraction fail.
+        agent = ReviewerAgent()
+        raw = (
+            "I need to check one concern — the `badgeHtml` inserted raw.\n\n"
+            "Looking at line 65:\n"
+            "```js\n"
+            "return `<button class=\"info-tab-btn${active}`;\n"
+            "```\n\n"
+            + VALID_JSON
+        )
+        result = agent._extract_json(raw)
+        assert result["summary"] == "One high finding."
+        assert len(result["findings"]) == 1
+
+    def test_returns_empty_findings_when_no_json_present(self):
+        agent = ReviewerAgent()
+        result = agent._extract_json("No JSON here at all.")
+        assert result["findings"] == []
+        assert "No JSON" in result["summary"]
+
+    def test_summary_fallback_truncated_to_200_chars(self):
+        agent = ReviewerAgent()
+        long_text = "x" * 300
+        result = agent._extract_json(long_text)
+        assert len(result["summary"]) == 200

--- a/tests/test_reviewer_agent.py
+++ b/tests/test_reviewer_agent.py
@@ -1,4 +1,6 @@
 """Unit tests for ReviewerAgent._extract_json."""
+import json
+
 from agents.reviewer_agent import ReviewerAgent
 
 
@@ -17,7 +19,7 @@ VALID_REVIEW = {
     "summary": "One high finding.",
 }
 
-VALID_JSON = '{"findings": [{"severity": "HIGH", "effort": "low", "fix_inline": false, "title": "Missing null check", "body": "foo can be null", "file": "src/foo.js", "line": 10}], "summary": "One high finding."}'
+VALID_JSON = json.dumps(VALID_REVIEW)
 
 
 class TestExtractJson:


### PR DESCRIPTION
Closes #46

Strategy 3 of ReviewerAgent._extract_json used raw.find("{") to locate the start of the JSON object. When Claude’s response contained prose with JS code snippets including template literals like `${active}`, the { inside ${active was found before the actual JSON opening brace, causing all extraction strategies to fail and the fallback to return raw[:200] as the summary.

Replaces the find/rfindRF substring approach with json.JSONDecoder.raw_decode, which iterates each { position and uses the decoder’s own parser to find the first valid JSON object regardless of preceding prose or code snippets. Adds tests/test_reviewer_agent.py with 5 tests including a regression case.

Generated with [Claude Code](https://claude.ai/code)