### PR TITLE
Task 3.3: Migrate ReviewerAgent to loader pattern

### DIFF
--- a/agents/reviewer_agent.py
+++ b/agents/reviewer_agent.py
@@ -1,76 +1,17 @@
 import json
 import os
+from pathlib import Path
+
 from github import Github
-from agents.base_agent import run_claude, RateLimitError, PromptTooLongError, TransientError  # noqa: F401
+from agents.base_agent import (
+    BaseAgent, OutputContractError, run_claude,
+    RateLimitError, PromptTooLongError, TransientError, REPO_DIR  # noqa: F401
+)
+from orchestrator.loader import compose_prompt, load_registry
 
-REVIEWER_PROMPT = """You are a code reviewer for Spades Online, a digital card game implementation.
 
-Review the provided code changes and categorize all findings by severity.
-
-IMPORTANT: If this is a retry attempt (previous review history is provided below),
-focus only on the SINGLE most important remaining blocking issue. Do not re-report
-issues that have already been addressed. Reporting one clear issue at a time helps
-the coder converge rather than getting overwhelmed.
-
-Review the provided code changes and categorize all findings by severity:
-
-CRITICAL: Must fix before merge
-- Security issues (e.g. card data exposed to wrong client, auth bypass)
-- Game rule violations (e.g. illegal moves not rejected, bid logic wrong)
-- Data loss or corruption risks
-
-HIGH: Must fix before merge
-- Bugs that would cause incorrect behavior or crashes
-- Memory leaks or resource mismanagement
-- Missing error handling on critical paths
-
-MEDIUM: Should fix, but won't block merge
-- Performance issues or inefficient patterns
-- Unhandled edge cases that are unlikely but possible
-- Missing input validation on non-critical paths
-
-LOW: Nice to fix eventually
-- Style and naming convention issues
-- Minor code clarity improvements
-- Redundant code
-
-For each finding also assess implementation effort:
-- "low": a one or two line change, trivial to implement, no design decisions needed
-  (e.g. add a missing null check, rename a variable, add a missing await, add a comment)
-- "high": requires design thought, touches multiple files, or has unclear best approach
-  (e.g. refactor a module, add a new abstraction, change a data model)
-
-Set fix_inline to true when BOTH of these are true:
-- severity is "MEDIUM" or "LOW"
-- effort is "low"
-
-These will be fixed immediately in the same PR rather than creating backlog issues.
-
-IMPORTANT: Do not generate MEDIUM or LOW findings for test files (any file under
-test/ or ending in .test.js, .spec.js). Test style, structure, and minor quality
-issues in test files are not worth tracking as backlog items. Only flag CRITICAL
-or HIGH findings in test files (e.g. a test that asserts the wrong expected value,
-or a test that could never fail).
-
-Respond ONLY with a valid JSON object in this exact format — no preamble, no markdown:
-
-{
-  "findings": [
-    {
-      "severity": "CRITICAL" | "HIGH" | "MEDIUM" | "LOW",
-      "effort": "low" | "high",
-      "fix_inline": true | false,
-      "title": "Short title for a GitHub issue",
-      "body": "Detailed description of the problem and suggested fix",
-      "file": "path/to/file.js or null",
-      "line": 42 or null
-    }
-  ],
-  "summary": "One or two sentence overall assessment"
-}
-
-If there are no findings, return an empty findings array.
-"""
+_ORCHESTRATOR_ROOT = Path(__file__).parent.parent
+_TARGET_ROOT = Path(REPO_DIR)
 
 
 def get_repo():
@@ -78,10 +19,39 @@ def get_repo():
     return g.get_repo(os.getenv("GITHUB_REPO"))
 
 
-class ReviewerAgent:
+class ReviewerAgent(BaseAgent):
     # Max diff chars to send to the reviewer — roughly 100k tokens worth.
     # If the diff exceeds this, we truncate and note it so Claude knows.
     MAX_DIFF_CHARS = 80_000
+
+    def parse_response(self, text: str) -> dict:
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            pass
+
+        clean = text.replace("```json", "").replace("```", "").strip()
+        try:
+            return json.loads(clean)
+        except json.JSONDecodeError:
+            pass
+
+        decoder = json.JSONDecoder()
+        for t in (text, clean):
+            for i, ch in enumerate(t):
+                if ch == '{':
+                    try:
+                        obj, _ = decoder.raw_decode(t, i)
+                        return obj
+                    except json.JSONDecodeError:
+                        continue
+
+        raise OutputContractError(
+            agent="reviewer",
+            task="review",
+            expected="valid JSON with keys: findings, summary",
+            got_preview=text[:200],
+        )
 
     def review(self, code_changes: str, review_history: list | None = None) -> dict:
         print("[Reviewer] Analyzing code changes...")
@@ -96,32 +66,34 @@ class ReviewerAgent:
             code_changes = truncated + note
             print(f"[Reviewer] Warning: diff truncated to {self.MAX_DIFF_CHARS} chars.")
 
-        history_section = ""
+        history_str = ""
         if review_history:
-            history_section = "\n\nPrevious review attempts (do not re-report already-fixed issues):\n"
+            history_str = "\n\nPrevious review attempts (do not re-report already-fixed issues):\n"
             for i, h in enumerate(review_history, 1):
-                history_section += f"\nAttempt {i}: {h}\n"
+                history_str += f"\nAttempt {i}: {h}\n"
 
-        prompt = (
-            f"{REVIEWER_PROMPT}\n\n"
-            f"Code changes to review:\n\n{code_changes}"
-            f"{history_section}"
-        )
+        registry = load_registry(_ORCHESTRATOR_ROOT, _TARGET_ROOT)
+        context = {"code_changes": code_changes, "review_history": history_str}
 
         try:
+            prompt = compose_prompt(
+                "reviewer", "review", context, registry, _ORCHESTRATOR_ROOT, _TARGET_ROOT
+            )
             raw = run_claude(prompt, allowed_tools="Read,Bash", model="claude-sonnet-4-6")
         except PromptTooLongError:
-            # Even after truncation the prompt is too long — truncate more aggressively
             hard_limit = self.MAX_DIFF_CHARS // 4
             truncated = code_changes[:hard_limit]
             note = (
                 f"\n\n[DIFF HEAVILY TRUNCATED: showing first {hard_limit} chars only]"
             )
-            prompt = f"{REVIEWER_PROMPT}\n\nCode changes to review:\n\n{truncated}{note}"
+            context = {"code_changes": truncated + note, "review_history": history_str}
+            prompt = compose_prompt(
+                "reviewer", "review", context, registry, _ORCHESTRATOR_ROOT, _TARGET_ROOT
+            )
             print(f"[Reviewer] Warning: hard truncating diff to {hard_limit} chars.")
             raw = run_claude(prompt, allowed_tools="Read,Bash", model="claude-sonnet-4-6")
 
-        result = self._extract_json(raw)
+        result = self.parse_response(raw)
 
         findings = result.get("findings", [])
         summary = result.get("summary", "")
@@ -229,7 +201,7 @@ class ReviewerAgent:
         Determine whether a CI failure is caused by a bug in the implementation
         or an incorrect test. Returns {"is_test_bug": bool, "confidence": str, "reasoning": str}.
         """
-        triage_prompt = """You are triaging a CI failure for the Spades Online card game.
+        triage_prompt = """You are triaging a CI failure for a software project.
 
 Given the CI failure output and the code changes in this PR, determine whether
 the failure is caused by:

--- a/defaults/agents.toml
+++ b/defaults/agents.toml
@@ -3,6 +3,7 @@
 # root-level agents.toml — see docs/orchestrator-refactor-prd.md §3 for merge rules.
 primary_language = "the project's primary programming language"
 codebase_layout_hint = "the project's main source directories and test directory"
+test_file_pattern = "test_*.py"
 
 [agents.tester]
 identity = "You are a test-writing agent that produces well-structured, independent tests following TDD principles."

--- a/defaults/agents.toml
+++ b/defaults/agents.toml
@@ -21,3 +21,9 @@ identity = "You are an issue decomposition agent that assesses GitHub issue comp
 model = "claude-sonnet-4-6"
 tools = ["Read", "Bash"]
 tasks = ["decompose"]
+
+[agents.reviewer]
+identity = "You are a code reviewer that evaluates changes for correctness, security, and quality."
+model = "claude-sonnet-4-6"
+tools = ["Read", "Bash"]
+tasks = ["review"]

--- a/defaults/prompts/reviewer/review.md
+++ b/defaults/prompts/reviewer/review.md
@@ -1,0 +1,72 @@
+You are a code reviewer.
+
+Review the provided code changes and categorize all findings by severity.
+
+IMPORTANT: If this is a retry attempt (previous review history is provided below),
+focus only on the SINGLE most important remaining blocking issue. Do not re-report
+issues that have already been addressed. Reporting one clear issue at a time helps
+the coder converge rather than getting overwhelmed.
+
+Code changes to review:
+
+{{code_changes}}
+{{review_history}}
+
+Review the provided code changes and categorize all findings by severity:
+
+CRITICAL: Must fix before merge
+- Security issues (e.g. authentication bypass, authorization failures, sensitive data exposure)
+- Data integrity violations (e.g. silent data corruption, incorrect write to storage)
+- Data loss or corruption risks
+
+HIGH: Must fix before merge
+- Bugs that would cause incorrect behavior or crashes
+- Memory leaks or resource mismanagement
+- Missing error handling on critical paths
+
+MEDIUM: Should fix, but won't block merge
+- Performance issues or inefficient patterns
+- Unhandled edge cases that are unlikely but possible
+- Missing input validation on non-critical paths
+
+LOW: Nice to fix eventually
+- Style and naming convention issues
+- Minor code clarity improvements
+- Redundant code
+
+For each finding also assess implementation effort:
+- "low": a one or two line change, trivial to implement, no design decisions needed
+  (e.g. add a missing null check, rename a variable, add a missing await, add a comment)
+- "high": requires design thought, touches multiple files, or has unclear best approach
+  (e.g. refactor a module, add a new abstraction, change a data model)
+
+Set fix_inline to true when BOTH of these are true:
+- severity is "MEDIUM" or "LOW"
+- effort is "low"
+
+These will be fixed immediately in the same PR rather than creating backlog issues.
+
+IMPORTANT: Do not generate MEDIUM or LOW findings for files matching {{test_file_pattern}}.
+Only flag CRITICAL or HIGH findings in test files (e.g. a test that asserts the wrong
+expected value, or a test that could never fail).
+
+<!-- ORCHESTRATOR OUTPUT CONTRACT — DO NOT MODIFY -->
+
+Respond ONLY with a valid JSON object in this exact format — no preamble, no markdown:
+
+{
+  "findings": [
+    {
+      "severity": "CRITICAL" | "HIGH" | "MEDIUM" | "LOW",
+      "effort": "low" | "high",
+      "fix_inline": true | false,
+      "title": "Short title for a GitHub issue",
+      "body": "Detailed description of the problem and suggested fix",
+      "file": "path/to/file.ext or null",
+      "line": 42 or null
+    }
+  ],
+  "summary": "One or two sentence overall assessment"
+}
+
+If there are no findings, return an empty findings array.

--- a/orchestrator/orchestrator.py
+++ b/orchestrator/orchestrator.py
@@ -2,13 +2,17 @@
 import asyncio
 import os
 
-from github import Github
+from dotenv import load_dotenv
+load_dotenv()  # must run before orchestrator imports
 
-from orchestrator.graph import build_graph, CHECKPOINT_DB, AsyncSqliteSaver
-from orchestrator.issue_selector import get_highest_priority_unassigned_issue
-from agents.base_agent import RateLimitError, TransientError, PromptTooLongError, OutputContractError
-from langgraph.types import Command
-from langgraph.errors import GraphInterrupt
+from github import Github  # noqa: E402
+
+from orchestrator.graph import build_graph, CHECKPOINT_DB  # noqa: E402
+from orchestrator.issue_selector import get_highest_priority_unassigned_issue  # noqa: E402
+from agents.base_agent import RateLimitError, TransientError, PromptTooLongError, OutputContractError  # noqa: E402
+from langgraph.types import Command  # noqa: E402
+from langgraph.errors import GraphInterrupt  # noqa: E402
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver  # noqa: E402
 
 STOP_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "STOP")
 

--- a/tests/test_reviewer_agent.py
+++ b/tests/test_reviewer_agent.py
@@ -1,7 +1,9 @@
-"""Unit tests for ReviewerAgent._extract_json."""
+"""Unit tests for ReviewerAgent.parse_response and _extract_json."""
 import json
 
+import pytest
 from agents.reviewer_agent import ReviewerAgent
+from agents.base_agent import OutputContractError
 
 
 VALID_REVIEW = {
@@ -63,3 +65,34 @@ class TestExtractJson:
         long_text = "x" * 300
         result = agent._extract_json(long_text)
         assert len(result["summary"]) == 200
+
+
+class TestParseResponse:
+    def setup_method(self):
+        self.agent = ReviewerAgent()
+
+    def test_parse_response_direct_json(self):
+        result = self.agent.parse_response(VALID_JSON)
+        assert result["summary"] == "One high finding."
+        assert len(result["findings"]) == 1
+
+    def test_parse_response_markdown_fenced_json(self):
+        raw = f"```json\n{VALID_JSON}\n```"
+        result = self.agent.parse_response(raw)
+        assert result["summary"] == "One high finding."
+
+    def test_parse_response_json_with_prose_preamble(self):
+        raw = f"Here is my review:\n\n{VALID_JSON}"
+        result = self.agent.parse_response(raw)
+        assert result["summary"] == "One high finding."
+
+    def test_parse_response_raises_on_plain_text(self):
+        with pytest.raises(OutputContractError) as exc_info:
+            self.agent.parse_response("No issues found in this change.")
+        err = exc_info.value
+        assert err.agent == "reviewer"
+        assert err.task == "review"
+
+    def test_parse_response_raises_on_empty_string(self):
+        with pytest.raises(OutputContractError):
+            self.agent.parse_response("")


### PR DESCRIPTION
Closes #16

## Summary

- Extract `REVIEWER_PROMPT` to `defaults/prompts/reviewer/review.md` with language-agnostic rubric and `{{test_file_pattern}}` variable
- `ReviewerAgent` now inherits from `BaseAgent`; `parse_response` raises `OutputContractError` on parse failure
- `review()` uses `compose_prompt` + `load_registry`; registered in `defaults/agents.toml`

## Acceptance criteria

- ✅ `grep "Spades\|card\|bid\|\.test\.js" defaults/prompts/reviewer/` returns nothing
- ✅ 67 tests passing
- ⏳ Reviewer still produces findings on a Spades PR (requires human validation)

Generated with [Claude Code](https://claude.ai/code)