### PR TITLE
Graceful exit on keyboard interrupt

### DIFF
--- a/main.py
+++ b/main.py
@@ -69,4 +69,8 @@ def _print_usage():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\nInterrupted.")
+        sys.exit(0)

--- a/orchestrator/orchestrator.py
+++ b/orchestrator/orchestrator.py
@@ -5,14 +5,14 @@ import os
 from dotenv import load_dotenv
 load_dotenv()   # ← must run before orchestrator imports
 
-from github import Github
+from github import Github  # noqa: E402
 
-from orchestrator.graph import build_graph, CHECKPOINT_DB
-from orchestrator.issue_selector import get_highest_priority_unassigned_issue
-from agents.base_agent import RateLimitError, TransientError, PromptTooLongError, OutputContractError
-from langgraph.types import Command
-from langgraph.errors import GraphInterrupt
-from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+from orchestrator.graph import build_graph, CHECKPOINT_DB  # noqa: E402
+from orchestrator.issue_selector import get_highest_priority_unassigned_issue  # noqa: E402
+from agents.base_agent import RateLimitError, TransientError, PromptTooLongError, OutputContractError  # noqa: E402
+from langgraph.types import Command  # noqa: E402
+from langgraph.errors import GraphInterrupt  # noqa: E402
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver  # noqa: E402
 
 STOP_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "STOP")
 

--- a/orchestrator/orchestrator.py
+++ b/orchestrator/orchestrator.py
@@ -195,6 +195,10 @@ class SpadesOrchestrator:
                     current_issue = None
                     rate_limit_retries = 0
 
+                except (KeyboardInterrupt, asyncio.CancelledError):
+                    print("\n[Orchestrator] Interrupted — shutting down gracefully.")
+                    return
+
     async def _check_auto_approvals(self):
         """
         Scan for issues labelled both 'needs-approval' and 'auto-approve-split'.


### PR DESCRIPTION
Closes #51

Catch `asyncio.CancelledError` and `KeyboardInterrupt` in `run_forever()` and at the `asyncio.run()` call site so Ctrl+C exits cleanly instead of dumping a traceback.

### Acceptance criteria

✅ `KeyboardInterrupt` no longer produces a traceback — verified by code inspection
✅ `asyncio.CancelledError` caught in `run_forever()` with a clean shutdown message

Generated with [Claude Code](https://claude.ai/code)