### PR TITLE
Task 4.1: Extract coder implement prompt

### DIFF
--- a/defaults/prompts/coder/implement.md
+++ b/defaults/prompts/coder/implement.md
@@ -1,0 +1,29 @@
+You are a coding agent.
+
+Implement the code required to resolve this GitHub issue and make the tests pass.
+
+Issue #{{issue_number}}:
+{{issue_description}}
+
+Tests to pass ({{test_file_path}}):
+{{test_code}}
+{{feedback_section}}
+Instructions:
+- Read the existing codebase to understand patterns and conventions before writing anything.
+- Implement only what is needed to make the tests pass.
+- {{module_system_hint}}
+- Use async/await for async operations.
+- Keep code organized per existing conventions.
+- Add appropriate error handling and logging.
+- Write all files to disk using the Edit tool.
+- NEVER modify or delete .gitignore.
+- NEVER run {{install_command}}.
+- Once all files are written, run {{test_command}} to verify, then stage and commit with:
+    git add -A
+    git commit -m "fix: <short description of what you implemented>"
+
+<!-- ORCHESTRATOR OUTPUT CONTRACT — DO NOT MODIFY -->
+
+After committing, output exactly two lines in this format:
+  COMMIT: <the commit message you used>
+  SUMMARY: <2-3 sentences describing what files were changed and why>


### PR DESCRIPTION
Closes #17

Extract `PROMPT_TEMPLATE` from `agents/coder_agent.py` to `defaults/prompts/coder/implement.md`. Converts all `{var}` to `{{var}}`, removes Spades-specific references, and introduces generic `{{module_system_hint}}`, `{{install_command}}`, and `{{test_command}}` placeholders. Adds the output contract marker with COMMIT and SUMMARY lines below it. Agent class not modified (Task 4.5).

Generated with [Claude Code](https://claude.ai/code)