### PR TITLE
Task 4.3: Extract coder fix-ci prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Populated by the orchestrator or individual agents at runtime. They come from th
 | `{{issue_number}}` | `orchestrator.py` | GitHub issue number (integer). Available to all agents. |
 | `{{issue_title}}` | `orchestrator.py` | GitHub issue title string. Used by `issue-decomposer/decompose.md`. |
 | `{{issue_body}}` | `orchestrator.py` | Full GitHub issue body text. Falls back to the title if the body is empty. Used by `issue-decomposer/decompose.md`. |
-| `{{issue_description}}` | `test_agent.py` | Alias for `issue_body` as passed downstream. Used by `coder/implement.md` and `tester/write-tests.md`. |
+| `{{issue_description}}` | `test_agent.py` | Alias for `issue_body` as passed downstream. Used by `coder/implement.md`, `tester/write-tests.md`, and `coder/fix-ci.md`. |
 | `{{test_file_path}}` | `test_agent.py` | Relative path to the test file written by the tester agent (e.g. `"tests/test_foo.py"`). Used by `coder/implement.md`. |
 | `{{test_code}}` | `test_agent.py` | Full contents of the test file at `{{test_file_path}}`. Used by `coder/implement.md`. |
 | `{{code_changes}}` | `coder_agent.py` / `reviewer_agent.py` | Output of `git diff origin/<default_branch>..HEAD` — the diff the coder produced. Used by `reviewer/review.md` and `docs-writer/document.md`. |

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Set in `[conventions]` of `agents.toml`. The target repo's `[conventions]` block
 | `{{test_file_pattern}}` | `"test_*.py"` | Glob pattern for locating test files (e.g. `"test_*.py"`, `"*.test.ts"`). Used by `reviewer/review.md` and `tester/write-tests.md`. |
 | `{{test_file_extension}}` | _(must be set by target repo)_ | File extension for new test files (e.g. `"py"`, `"test.ts"`). Used by `tester/write-tests.md`. |
 | `{{test_runner}}` | _(must be set by target repo)_ | Testing framework name (e.g. `"pytest"`, `"jest"`). Used by `tester/write-tests.md`. |
-| `{{test_command}}` | _(must be set by target repo)_ | Shell command to run the test suite (e.g. `"pytest"`, `"npm test"`). Used by `coder/implement.md`. |
-| `{{install_command}}` | _(must be set by target repo)_ | Dependency install command (e.g. `"pip install -r requirements.txt"`). Used in `coder/implement.md` to tell the coder **not** to run it. |
+| `{{test_command}}` | _(must be set by target repo)_ | Shell command to run the test suite (e.g. `"pytest"`, `"npm test"`). Used by `coder/implement.md` and `coder/fix-ci.md`. |
+| `{{install_command}}` | _(must be set by target repo)_ | Dependency install command (e.g. `"pip install -r requirements.txt"`). Used in `coder/implement.md`, `coder/fix-review.md`, and `coder/fix-ci.md` to tell the coder **not** to run it. |
 | `{{module_system_hint}}` | _(must be set by target repo)_ | Short description of the import/module system (e.g. `"Python imports"`, `"ES Modules with named exports"`). Used by `coder/implement.md`. |
 
 ### Runtime context variables
@@ -93,6 +93,7 @@ Populated by the orchestrator or individual agents at runtime. They come from th
 | `{{review_history}}` | `reviewer_agent.py` | Accumulated text from all prior review rounds. Used by `reviewer/review.md` so the reviewer can avoid repeating itself. |
 | `{{feedback_section}}` | `coder_agent.py` | Reviewer feedback or retry context injected into the coder's re-attempt prompt. Used by `coder/implement.md`. |
 | `{{reviewer_feedback}}` | `coder_agent.py` | Feedback text from the reviewer agent listing specific issues the coder must fix. Passed from the orchestrator context into the fix-review prompt. Used by `coder/fix-review.md`. |
+| `{{ci_errors}}` | `coder_agent.py` | CI failure output and diagnosis text. Passed when the orchestrator detects a failing CI run on a PR. Used by `coder/fix-ci.md`. |
 
 ### Adding a new variable
 

--- a/defaults/prompts/coder/fix-ci.md
+++ b/defaults/prompts/coder/fix-ci.md
@@ -1,0 +1,29 @@
+You are a coding agent.
+
+CI checks failed on the PR for issue #{{issue_number}}. Your job is to fix the
+failing tests — do not rewrite working code. Read the existing implementation
+on this branch first, then make the minimum changes needed to make CI pass.
+
+Issue #{{issue_number}}:
+{{issue_description}}
+
+CI failure details and diagnosis:
+{{ci_errors}}
+
+Instructions:
+- Read the existing files on this branch before making any changes.
+- Make targeted fixes only — do not refactor beyond what is needed to fix CI.
+- If the diagnosis says the TEST is wrong, fix the test assertions.
+- If the diagnosis says the IMPLEMENTATION is wrong, fix the implementation.
+- NEVER modify or delete .gitignore.
+- NEVER run {{install_command}}.
+- Write all changes to disk using the Edit tool.
+- Once all fixes are applied, run {{test_command}} to verify, then stage and commit with:
+    git add -A
+    git commit -m "fix: resolve CI failure for issue #{{issue_number}}"
+
+<!-- ORCHESTRATOR OUTPUT CONTRACT — DO NOT MODIFY -->
+
+After committing, output exactly two lines in this format:
+  COMMIT: <the commit message you used>
+  SUMMARY: <2-3 sentences describing what you changed and why>


### PR DESCRIPTION
Closes #19

Extracts `CI_FIX_PROMPT_TEMPLATE` from `agents/coder_agent.py` to `defaults/prompts/coder/fix-ci.md`. Removes Spades-isms, converts placeholders to `{{variable}}` format (including `{{ci_errors}}` and `{{test_command}}`), and places the output contract marker above the output format section. Updates README.md to document the new `{{ci_errors}}` variable. Agent wiring is deferred to Task 4.5.

Generated with [Claude Code](https://claude.ai/code)