### PR TITLE
Task 4.4: Extract coder fix-inline prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Populated by the orchestrator or individual agents at runtime. They come from th
 | `{{feedback_section}}` | `coder_agent.py` | Reviewer feedback or retry context injected into the coder's re-attempt prompt. Used by `coder/implement.md`. |
 | `{{reviewer_feedback}}` | `coder_agent.py` | Feedback text from the reviewer agent listing specific issues the coder must fix. Passed from the orchestrator context into the fix-review prompt. Used by `coder/fix-review.md`. |
 | `{{ci_errors}}` | `coder_agent.py` | CI failure output and diagnosis text. Passed when the orchestrator detects a failing CI run on a PR. Used by `coder/fix-ci.md`. |
+| `{{inline_findings}}` | `coder_agent.py` | Formatted list of low-effort inline review fixes the coder must apply immediately in the current PR. Used by `coder/fix-inline.md`. |
 
 ### Adding a new variable
 

--- a/defaults/prompts/coder/fix-inline.md
+++ b/defaults/prompts/coder/fix-inline.md
@@ -1,0 +1,20 @@
+The code for issue #{{issue_number}} has been implemented and reviewed. The reviewer
+found the following low-effort improvements that should be fixed immediately in this
+PR rather than deferred to the backlog. Each fix should be a small, targeted change.
+
+Inline fixes to apply:
+{{inline_findings}}
+
+Instructions:
+- Read the relevant files before making any changes.
+- Apply each fix as a minimal, targeted change — do not refactor beyond what is listed.
+- Write all changes to disk using the Edit tool.
+- Once all fixes are applied, stage and commit with:
+    git add -A
+    git commit -m "fix: apply inline review fixes for issue #{{issue_number}}"
+
+<!-- ORCHESTRATOR OUTPUT CONTRACT — DO NOT MODIFY -->
+
+After committing, output exactly two lines in this format:
+  COMMIT: <the commit message you used>
+  SUMMARY: <2-3 sentences describing what files were changed and why>


### PR DESCRIPTION
Closes #20

Extracted `INLINE_FIX_PROMPT_TEMPLATE` from `agents/coder_agent.py` to `defaults/prompts/coder/fix-inline.md`. Converted single-brace placeholders to double-brace format, removed the Spades-ism opening line, and placed the output format below the output contract marker.

**Acceptance criteria:**
- ✅ `defaults/prompts/coder/fix-inline.md` exists
- ✅ No Spades-isms (`grep "Spades\|ES Modules\|npm\|node_modules\|server/game"` returns nothing)

Generated with [Claude Code](https://claude.ai/code)