### PR TITLE
Task 5.1: Add product-planner agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Populated by the orchestrator or individual agents at runtime. They come from th
 | `{{reviewer_feedback}}` | `coder_agent.py` | Feedback text from the reviewer agent listing specific issues the coder must fix. Passed from the orchestrator context into the fix-review prompt. Used by `coder/fix-review.md`. |
 | `{{ci_errors}}` | `coder_agent.py` | CI failure output and diagnosis text. Passed when the orchestrator detects a failing CI run on a PR. Used by `coder/fix-ci.md`. |
 | `{{inline_findings}}` | `coder_agent.py` | Formatted list of low-effort inline review fixes the coder must apply immediately in the current PR. Used by `coder/fix-inline.md`. |
+| `{{brief}}` | `scripts/run_agent.py` | Product brief text passed as `--input` to `product-planner draft-prd`. Used by `product-planner/draft-prd.md`. |
+| `{{prd}}` | `scripts/run_agent.py` | Full PRD text passed as `--input` to `product-planner propose-issues`. Used by `product-planner/propose-issues.md`. |
 
 ### Adding a new variable
 

--- a/agents/config_driven_agent.py
+++ b/agents/config_driven_agent.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from agents.base_agent import BaseAgent, run_claude, REPO_DIR
+from orchestrator.loader import compose_prompt, load_registry
+
+_ORCHESTRATOR_ROOT = Path(__file__).parent.parent
+_TARGET_ROOT = Path(REPO_DIR)
+
+
+class ConfigDrivenAgent(BaseAgent):
+    """Generic agent that reads identity, model, and tools from agents.toml.
+
+    Subclasses override parse_response for structured output; agents with
+    unstructured output (returning plain text) use this class directly.
+    """
+
+    def __init__(self, agent_name: str):
+        self.agent_name = agent_name
+
+    async def run(self, context: dict) -> dict:
+        task = context["task"]
+        registry = load_registry(_ORCHESTRATOR_ROOT, _TARGET_ROOT)
+        agent_config = registry.get("agents", {}).get(self.agent_name, {})
+        model = agent_config.get("model", "claude-sonnet-4-6")
+        tools = ",".join(agent_config.get("tools", ["Read", "Bash"]))
+        prompt = compose_prompt(
+            self.agent_name, task, context, registry, _ORCHESTRATOR_ROOT, _TARGET_ROOT
+        )
+        response = run_claude(prompt, allowed_tools=tools, model=model)
+        parsed = self.parse_response(response)
+        return {"agent": self.agent_name, "task": task, **parsed}

--- a/agents/product_planner_agent.py
+++ b/agents/product_planner_agent.py
@@ -1,0 +1,65 @@
+import json
+import re
+from pathlib import Path
+
+from agents.base_agent import BaseAgent, OutputContractError, run_claude, REPO_DIR
+from agents.config_driven_agent import ConfigDrivenAgent
+from orchestrator.loader import compose_prompt, load_registry
+
+_ORCHESTRATOR_ROOT = Path(__file__).parent.parent
+_TARGET_ROOT = Path(REPO_DIR)
+
+
+class ProductPlannerAgent(ConfigDrivenAgent):
+    def __init__(self):
+        super().__init__("product-planner")
+
+    def parse_response(self, text: str) -> dict:
+        """Extract a JSON array of proposed issues (for propose-issues task).
+
+        Tries direct JSON parse, then markdown-fence-stripped parse, then a
+        bracket-delimited search.  Raises OutputContractError if none succeed.
+        """
+        cleaned = text.strip()
+        if cleaned.startswith("```"):
+            lines = cleaned.split("\n")
+            inner = lines[1:-1] if lines[-1].strip() == "```" else lines[1:]
+            cleaned = "\n".join(inner)
+        try:
+            parsed = json.loads(cleaned)
+            if isinstance(parsed, list):
+                return {"issues": parsed}
+        except json.JSONDecodeError:
+            pass
+        match = re.search(r"\[.*\]", text, re.DOTALL)
+        if match:
+            try:
+                parsed = json.loads(match.group())
+                if isinstance(parsed, list):
+                    return {"issues": parsed}
+            except json.JSONDecodeError:
+                pass
+        raise OutputContractError(
+            agent="product-planner",
+            task="propose-issues",
+            expected="JSON array of proposed issues",
+            got_preview=text[:200],
+        )
+
+    async def run(self, context: dict) -> dict:
+        task = context["task"]
+        registry = load_registry(_ORCHESTRATOR_ROOT, _TARGET_ROOT)
+        agent_config = registry.get("agents", {}).get(self.agent_name, {})
+        model = agent_config.get("model", "claude-sonnet-4-6")
+        tools = ",".join(agent_config.get("tools", ["Read", "Bash"]))
+        prompt = compose_prompt(
+            "product-planner", task, context, registry, _ORCHESTRATOR_ROOT, _TARGET_ROOT
+        )
+        response = run_claude(prompt, allowed_tools=tools, model=model)
+
+        if task == "draft-prd":
+            parsed = BaseAgent.parse_response(self, response)
+        else:
+            parsed = self.parse_response(response)
+
+        return {"agent": "product-planner", "task": task, **parsed}

--- a/defaults/agents.toml
+++ b/defaults/agents.toml
@@ -37,3 +37,10 @@ identity = "You are a code reviewer that evaluates changes for correctness, secu
 model = "claude-sonnet-4-6"
 tools = ["Read", "Bash"]
 tasks = ["review"]
+
+[agents."product-planner"]
+identity = "You are a product planning agent that turns product briefs into structured PRDs and actionable GitHub issues."
+model = "claude-sonnet-4-6"
+tools = ["Read", "Bash"]
+tasks = ["draft-prd", "propose-issues"]
+prompt_dir = "prompts/product-planner"

--- a/defaults/prompts/product-planner/draft-prd.md
+++ b/defaults/prompts/product-planner/draft-prd.md
@@ -1,0 +1,16 @@
+You are a product planning agent. Your task is to write a Product Requirements Document (PRD) from a product brief.
+
+Given the brief below, produce a clear, structured PRD with the following sections:
+
+1. **Overview** — one-paragraph summary of the product or feature.
+2. **Problem statement** — what user pain point or gap is being addressed.
+3. **Goals** — 3–5 measurable success criteria.
+4. **Non-goals** — explicit scope exclusions to prevent scope creep.
+5. **User stories** — key use cases in "As a <user>, I want <action> so that <benefit>" form.
+6. **Functional requirements** — numbered list of concrete requirements.
+7. **Open questions** — unresolved decisions that need answers before implementation starts.
+
+Be concise. Prefer short paragraphs and bullet points over walls of text.
+
+Brief:
+{{brief}}

--- a/defaults/prompts/product-planner/propose-issues.md
+++ b/defaults/prompts/product-planner/propose-issues.md
@@ -1,0 +1,26 @@
+You are a product planning agent. Your task is to propose a set of GitHub issues that would implement the product described in the PRD below.
+
+For each issue:
+- Give it a short, imperative title (e.g. "Add user authentication endpoint").
+- Write a body that describes the goal, key steps, and acceptance criteria.
+- Keep issues independently implementable where possible.
+- Aim for 5–15 issues depending on scope.
+
+PRD:
+{{prd}}
+
+<!-- ORCHESTRATOR OUTPUT CONTRACT — DO NOT MODIFY -->
+
+Respond with a JSON array and nothing else. Each element must be an object with exactly two keys:
+- `"title"`: string — the issue title.
+- `"body"`: string — the issue body in Markdown.
+
+Example:
+```json
+[
+  {"title": "Add login endpoint", "body": "## Goal\nImplement POST /auth/login...\n\n## Acceptance\n- Returns JWT on valid credentials\n- Returns 401 on invalid credentials"},
+  {"title": "Add logout endpoint", "body": "## Goal\n..."}
+]
+```
+
+Output only the JSON array. Do not include any explanation or prose outside the array.

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Run a single agent task from the command line.
+
+Usage:
+    python scripts/run_agent.py <agent-name> <task-name> [--input FILE] [--context KEY=VALUE ...]
+
+Examples:
+    python scripts/run_agent.py product-planner draft-prd --input some-brief.txt
+    python scripts/run_agent.py product-planner propose-issues --input prd.md
+    python scripts/run_agent.py product-planner draft-prd --context brief="A note-taking app for developers"
+
+The --input file contents are injected as the primary context variable for the task:
+  draft-prd       -> {{brief}}
+  propose-issues  -> {{prd}}
+  (other tasks)   -> {{input}}
+"""
+import argparse
+import asyncio
+import importlib
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Maps agent name -> fully-qualified class path
+_AGENT_CLASSES: dict[str, str] = {
+    "product-planner": "agents.product_planner_agent.ProductPlannerAgent",
+}
+
+# Maps task name -> context variable name for --input
+_TASK_INPUT_VARS: dict[str, str] = {
+    "draft-prd": "brief",
+    "propose-issues": "prd",
+}
+
+
+def _load_agent_class(agent_name: str):
+    if agent_name not in _AGENT_CLASSES:
+        known = ", ".join(sorted(_AGENT_CLASSES))
+        print(f"Unknown agent: {agent_name!r}. Known agents: {known}", file=sys.stderr)
+        sys.exit(1)
+    module_path, class_name = _AGENT_CLASSES[agent_name].rsplit(".", 1)
+    module = importlib.import_module(module_path)
+    return getattr(module, class_name)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run one agent task end-to-end against the Claude CLI.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("agent", help="Agent name (e.g. product-planner)")
+    parser.add_argument("task", help="Task name (e.g. draft-prd, propose-issues)")
+    parser.add_argument(
+        "--input", "-i",
+        metavar="FILE",
+        help="Input file; contents injected as the task's primary context variable",
+    )
+    parser.add_argument(
+        "--context", "-c",
+        nargs="*",
+        metavar="KEY=VALUE",
+        help="Additional context variables (may be repeated)",
+    )
+    args = parser.parse_args()
+
+    context: dict = {"task": args.task}
+
+    if args.input:
+        file_path = Path(args.input)
+        if not file_path.exists():
+            print(f"Input file not found: {args.input}", file=sys.stderr)
+            sys.exit(1)
+        content = file_path.read_text(encoding="utf-8")
+        var = _TASK_INPUT_VARS.get(args.task, "input")
+        context[var] = content
+
+    for pair in args.context or []:
+        if "=" not in pair:
+            print(f"Warning: skipping --context {pair!r} (expected KEY=VALUE)", file=sys.stderr)
+            continue
+        k, v = pair.split("=", 1)
+        context[k] = v
+
+    AgentClass = _load_agent_class(args.agent)
+    agent = AgentClass()
+    result = asyncio.run(agent.run(context))
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_product_planner_agent.py
+++ b/tests/test_product_planner_agent.py
@@ -1,0 +1,58 @@
+"""Unit tests for ProductPlannerAgent.parse_response (propose-issues task)."""
+import json
+import pytest
+from agents.product_planner_agent import ProductPlannerAgent
+from agents.base_agent import OutputContractError
+
+
+class TestParseResponse:
+    def test_returns_issues_on_plain_json_array(self):
+        agent = ProductPlannerAgent()
+        payload = [{"title": "Add login", "body": "Implement POST /login"}]
+        result = agent.parse_response(json.dumps(payload))
+        assert result["issues"] == payload
+
+    def test_returns_issues_on_markdown_fenced_json(self):
+        agent = ProductPlannerAgent()
+        payload = [{"title": "Add logout", "body": "Implement DELETE /session"}]
+        text = f"```json\n{json.dumps(payload)}\n```"
+        result = agent.parse_response(text)
+        assert result["issues"] == payload
+
+    def test_returns_issues_when_array_embedded_in_prose(self):
+        agent = ProductPlannerAgent()
+        payload = [{"title": "Issue A", "body": "Body A"}]
+        text = f"Here are the issues:\n{json.dumps(payload)}\nEnd."
+        result = agent.parse_response(text)
+        assert result["issues"] == payload
+
+    def test_returns_empty_list_on_empty_array(self):
+        agent = ProductPlannerAgent()
+        result = agent.parse_response("[]")
+        assert result["issues"] == []
+
+    def test_raises_output_contract_error_on_plain_text(self):
+        agent = ProductPlannerAgent()
+        with pytest.raises(OutputContractError) as exc_info:
+            agent.parse_response("This is just a PRD, not a JSON array.")
+        err = exc_info.value
+        assert err.agent == "product-planner"
+        assert err.task == "propose-issues"
+
+    def test_raises_output_contract_error_on_json_object(self):
+        agent = ProductPlannerAgent()
+        with pytest.raises(OutputContractError):
+            agent.parse_response('{"title": "oops", "body": "not an array"}')
+
+    def test_raises_output_contract_error_on_empty_string(self):
+        agent = ProductPlannerAgent()
+        with pytest.raises(OutputContractError) as exc_info:
+            agent.parse_response("")
+        assert exc_info.value.got_preview == ""
+
+    def test_got_preview_truncated_to_200_chars(self):
+        agent = ProductPlannerAgent()
+        long_text = "x" * 300
+        with pytest.raises(OutputContractError) as exc_info:
+            agent.parse_response(long_text)
+        assert len(exc_info.value.got_preview) == 200


### PR DESCRIPTION
Closes #22

Adds the `product-planner` agent (PRD §4.7) with two tasks: `draft-prd` and `propose-issues`. Also introduces `ConfigDrivenAgent(BaseAgent)` as a reusable base for all phase-5 agents.

## Changes

- `agents/config_driven_agent.py`: `ConfigDrivenAgent` reads identity, model, and tools from `agents.toml`
- `agents/product_planner_agent.py`: `ProductPlannerAgent` with draft-prd + propose-issues tasks
- `defaults/prompts/product-planner/draft-prd.md` and `propose-issues.md`
- `defaults/agents.toml`: product-planner entry
- `scripts/run_agent.py`: CLI for invoking any agent+task
- `README.md`: documents {{brief}} and {{prd}} runtime variables
- `tests/test_product_planner_agent.py`: 8 unit tests for parse_response

## Acceptance criteria

- ✅ `scripts/run_agent.py product-planner draft-prd --input some-brief.txt` is implemented
- ✅ `propose-issues` parse_response enforces JSON array output contract (8 unit tests pass)
- ✅ All 80 existing tests continue to pass
- ⏳ F3 end-to-end validation requires human to run against live Claude CLI

Generated with [Claude Code](https://claude.ai/code)