### PR TITLE
Task 5.2: Add triager agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Populated by the orchestrator or individual agents at runtime. They come from th
 | `{{inline_findings}}` | `coder_agent.py` | Formatted list of low-effort inline review fixes the coder must apply immediately in the current PR. Used by `coder/fix-inline.md`. |
 | `{{brief}}` | `scripts/run_agent.py` | Product brief text passed as `--input` to `product-planner draft-prd`. Used by `product-planner/draft-prd.md`. |
 | `{{prd}}` | `scripts/run_agent.py` | Full PRD text passed as `--input` to `product-planner propose-issues`. Used by `product-planner/propose-issues.md`. |
+| `{{input}}` | `scripts/run_agent.py` | Generic input text passed as `--input` for tasks not listed in `_TASK_INPUT_VARS` (e.g. `triager triage`). Used by `triager/triage.md`. |
 
 ### Adding a new variable
 

--- a/agents/triager_agent.py
+++ b/agents/triager_agent.py
@@ -1,0 +1,50 @@
+import json
+import re
+
+from agents.base_agent import OutputContractError
+from agents.config_driven_agent import ConfigDrivenAgent
+
+_REQUIRED_KEYS = {"classification", "suggested_agent", "reasoning"}
+_VALID_AGENTS = {"coder", "tester", "refactor"}
+
+
+class TriagerAgent(ConfigDrivenAgent):
+    def __init__(self):
+        super().__init__("triager")
+
+    def parse_response(self, text: str) -> dict:
+        """Extract JSON {classification, suggested_agent, reasoning} from Claude output.
+
+        Tries direct JSON parse, then markdown-fence-stripped parse, then a
+        brace-delimited search. Raises OutputContractError if none succeed or
+        required keys are missing.
+        """
+        cleaned = text.strip()
+        if cleaned.startswith("```"):
+            lines = cleaned.split("\n")
+            inner = lines[1:-1] if lines[-1].strip() == "```" else lines[1:]
+            cleaned = "\n".join(inner).strip()
+
+        candidates = [cleaned]
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        if match:
+            candidates.append(match.group())
+
+        for candidate in candidates:
+            try:
+                parsed = json.loads(candidate)
+                if isinstance(parsed, dict) and _REQUIRED_KEYS.issubset(parsed):
+                    return {
+                        "classification": parsed["classification"],
+                        "suggested_agent": parsed["suggested_agent"],
+                        "reasoning": parsed["reasoning"],
+                    }
+            except json.JSONDecodeError:
+                pass
+
+        raise OutputContractError(
+            agent="triager",
+            task="triage",
+            expected='JSON object with keys: classification, suggested_agent, reasoning',
+            got_preview=text[:200],
+        )

--- a/defaults/agents.toml
+++ b/defaults/agents.toml
@@ -44,3 +44,9 @@ model = "claude-sonnet-4-6"
 tools = ["Read", "Bash"]
 tasks = ["draft-prd", "propose-issues"]
 prompt_dir = "prompts/product-planner"
+
+[agents.triager]
+identity = "You are a triage agent that reads failing CI logs and bug reports, classifies the problem, and recommends which agent should handle it next."
+model = "claude-sonnet-4-6"
+tools = ["Read", "Bash"]
+tasks = ["triage"]

--- a/defaults/prompts/triager/triage.md
+++ b/defaults/prompts/triager/triage.md
@@ -1,0 +1,27 @@
+You are a triage agent. Your task is to analyse a failing CI log or bug report and determine what kind of problem it represents, which agent should handle it next, and why.
+
+Read the input carefully. Look for:
+- Compilation or syntax errors (likely a `coder` fix)
+- Failing tests or assertion errors (likely a `tester` fix or `coder` fix)
+- Code smell, complexity, or maintainability issues (likely a `refactor` fix)
+
+Input:
+{{input}}
+
+<!-- ORCHESTRATOR OUTPUT CONTRACT — DO NOT MODIFY -->
+
+Respond with a single JSON object and nothing else. The object must have exactly three keys:
+- `"classification"`: string — a short label describing the problem type (e.g. `"build failure"`, `"test failure"`, `"runtime error"`, `"code quality issue"`).
+- `"suggested_agent"`: string — exactly one of `"coder"`, `"tester"`, or `"refactor"`.
+- `"reasoning"`: string — one or two sentences explaining why you chose that classification and agent.
+
+Example:
+```json
+{
+  "classification": "test failure",
+  "suggested_agent": "tester",
+  "reasoning": "Two assertions in test_auth.py are failing because the expected status code changed. The tester agent should update the test expectations to match the new behaviour."
+}
+```
+
+Output only the JSON object. Do not include any explanation or prose outside the object.

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -27,6 +27,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 # Maps agent name -> fully-qualified class path
 _AGENT_CLASSES: dict[str, str] = {
     "product-planner": "agents.product_planner_agent.ProductPlannerAgent",
+    "triager": "agents.triager_agent.TriagerAgent",
 }
 
 # Maps task name -> context variable name for --input

--- a/tests/test_triager_agent.py
+++ b/tests/test_triager_agent.py
@@ -1,0 +1,72 @@
+"""Unit tests for TriagerAgent.parse_response."""
+import json
+import pytest
+from agents.triager_agent import TriagerAgent
+from agents.base_agent import OutputContractError
+
+
+_VALID_PAYLOAD = {
+    "classification": "test failure",
+    "suggested_agent": "tester",
+    "reasoning": "Two assertions are failing in test_auth.py.",
+}
+
+
+class TestParseResponse:
+    def test_returns_fields_on_plain_json_object(self):
+        agent = TriagerAgent()
+        result = agent.parse_response(json.dumps(_VALID_PAYLOAD))
+        assert result["classification"] == "test failure"
+        assert result["suggested_agent"] == "tester"
+        assert result["reasoning"] == "Two assertions are failing in test_auth.py."
+
+    def test_returns_fields_on_markdown_fenced_json(self):
+        agent = TriagerAgent()
+        text = f"```json\n{json.dumps(_VALID_PAYLOAD)}\n```"
+        result = agent.parse_response(text)
+        assert result["classification"] == "test failure"
+        assert result["suggested_agent"] == "tester"
+
+    def test_returns_fields_when_json_embedded_in_prose(self):
+        agent = TriagerAgent()
+        text = f"Here is my analysis:\n{json.dumps(_VALID_PAYLOAD)}\nEnd."
+        result = agent.parse_response(text)
+        assert result["suggested_agent"] == "tester"
+
+    def test_only_returns_required_keys(self):
+        agent = TriagerAgent()
+        payload = {**_VALID_PAYLOAD, "extra": "ignored"}
+        result = agent.parse_response(json.dumps(payload))
+        assert set(result.keys()) == {"classification", "suggested_agent", "reasoning"}
+
+    def test_raises_output_contract_error_on_plain_text(self):
+        agent = TriagerAgent()
+        with pytest.raises(OutputContractError) as exc_info:
+            agent.parse_response("This is a log with no JSON.")
+        err = exc_info.value
+        assert err.agent == "triager"
+        assert err.task == "triage"
+
+    def test_raises_output_contract_error_on_missing_key(self):
+        agent = TriagerAgent()
+        payload = {"classification": "build failure", "suggested_agent": "coder"}
+        with pytest.raises(OutputContractError):
+            agent.parse_response(json.dumps(payload))
+
+    def test_raises_output_contract_error_on_json_array(self):
+        agent = TriagerAgent()
+        with pytest.raises(OutputContractError):
+            agent.parse_response("[1, 2, 3]")
+
+    def test_raises_output_contract_error_on_empty_string(self):
+        agent = TriagerAgent()
+        with pytest.raises(OutputContractError) as exc_info:
+            agent.parse_response("")
+        assert exc_info.value.got_preview == ""
+
+    def test_got_preview_truncated_to_200_chars(self):
+        agent = TriagerAgent()
+        long_text = "x" * 300
+        with pytest.raises(OutputContractError) as exc_info:
+            agent.parse_response(long_text)
+        assert len(exc_info.value.got_preview) == 200


### PR DESCRIPTION
Closes #23

Adds the `triager` agent that reads failing CI logs and bug reports, classifies the problem, and recommends which agent should handle it next (`coder`, `tester`, or `refactor`).

## Acceptance criteria

- ✅ `TriagerAgent` reuses `ConfigDrivenAgent` from Task 5.1
- ✅ `parse_response` extracts `{classification, suggested_agent, reasoning}` and raises `OutputContractError` on malformed output
- ✅ Registered in `defaults/agents.toml`
- ✅ `scripts/run_agent.py` wired so `python scripts/run_agent.py triager triage --input some-ci-log.txt` works
- ⚳ Live end-to-end run against real CI log requires human validation
- ✅ Not wired into the LangGraph graph

Generated with [Claude Code](https://claude.ai/code)