### PR TITLE
Task 5.3: Add refactor agent

### DIFF
--- a/agents/refactor_agent.py
+++ b/agents/refactor_agent.py
@@ -1,0 +1,20 @@
+from agents.config_driven_agent import ConfigDrivenAgent
+from agents.base_agent import OutputContractError
+
+
+class RefactorAgent(ConfigDrivenAgent):
+    def __init__(self):
+        super().__init__("refactor")
+
+    def parse_response(self, text: str) -> dict:
+        for line in text.splitlines():
+            if line.startswith("COMMIT:"):
+                commit_message = line[len("COMMIT:"):].strip()
+                if commit_message:
+                    return {"commit_message": commit_message}
+        raise OutputContractError(
+            agent="refactor",
+            task="refactor",
+            expected="COMMIT: <message>",
+            got_preview=text[:200],
+        )

--- a/defaults/agents.toml
+++ b/defaults/agents.toml
@@ -45,6 +45,12 @@ tools = ["Read", "Bash"]
 tasks = ["draft-prd", "propose-issues"]
 prompt_dir = "prompts/product-planner"
 
+[agents.refactor]
+identity = "You are a refactoring agent that performs structural changes to code (rename, extract function, split module) without changing observable behaviour."
+model = "claude-sonnet-4-6"
+tools = ["Read", "Edit", "Bash"]
+tasks = ["refactor", "fix-review"]
+
 [agents.triager]
 identity = "You are a triage agent that reads failing CI logs and bug reports, classifies the problem, and recommends which agent should handle it next."
 model = "claude-sonnet-4-6"

--- a/defaults/prompts/refactor/fix-review.md
+++ b/defaults/prompts/refactor/fix-review.md
@@ -1,0 +1,20 @@
+You are a refactoring agent.
+
+A previous structural refactor was reviewed and the reviewer flagged issues listed below.
+Fix only the specific problems raised — do not redo the entire refactor or change anything
+that was not flagged. The refactored code is already on the branch; read it first.
+
+Issues to address:
+{{reviewer_feedback}}
+
+Instructions:
+- Read the existing files on this branch before making any changes.
+- Make targeted fixes only — do not restructure beyond what is listed.
+- After all edits are written to disk, stage and commit with:
+    git add -A
+    git commit -m "refactor: address review feedback"
+
+<!-- ORCHESTRATOR OUTPUT CONTRACT — DO NOT MODIFY -->
+
+After committing, output exactly one line in this format:
+  COMMIT: <the commit message you used>

--- a/defaults/prompts/refactor/refactor.md
+++ b/defaults/prompts/refactor/refactor.md
@@ -1,0 +1,21 @@
+You are a refactoring agent.
+
+Perform the structural change described below. The goal is to improve code structure
+(rename, extract function, split module, reorganise imports, etc.) **without changing
+observable behaviour**. Do not add new features or fix bugs beyond what is described.
+
+Refactor request:
+{{input}}
+
+Instructions:
+- Read the relevant files thoroughly before making any changes.
+- Make only the structural changes described above — do not alter logic or fix unrelated issues.
+- Update all call sites, imports, and references affected by the change.
+- After all edits are written to disk, stage and commit with:
+    git add -A
+    git commit -m "refactor: <short description of the structural change>"
+
+<!-- ORCHESTRATOR OUTPUT CONTRACT — DO NOT MODIFY -->
+
+After committing, output exactly one line in this format:
+  COMMIT: <the commit message you used>

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -27,6 +27,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 # Maps agent name -> fully-qualified class path
 _AGENT_CLASSES: dict[str, str] = {
     "product-planner": "agents.product_planner_agent.ProductPlannerAgent",
+    "refactor": "agents.refactor_agent.RefactorAgent",
     "triager": "agents.triager_agent.TriagerAgent",
 }
 

--- a/tests/test_refactor_agent.py
+++ b/tests/test_refactor_agent.py
@@ -1,0 +1,49 @@
+"""Unit tests for RefactorAgent.parse_response."""
+import pytest
+from agents.refactor_agent import RefactorAgent
+from agents.base_agent import OutputContractError
+
+
+class TestRefactorAgentParseResponse:
+    def setup_method(self):
+        self.agent = RefactorAgent()
+
+    def test_parse_response_extracts_commit_message(self):
+        text = "Some output\nCOMMIT: refactor: extract auth module\nTrailing text"
+        result = self.agent.parse_response(text)
+        assert result == {"commit_message": "refactor: extract auth module"}
+
+    def test_parse_response_returns_first_commit_line(self):
+        text = "COMMIT: refactor: first\nCOMMIT: refactor: second"
+        result = self.agent.parse_response(text)
+        assert result == {"commit_message": "refactor: first"}
+
+    def test_parse_response_strips_whitespace_from_message(self):
+        text = "COMMIT:   refactor: rename foo to bar   "
+        result = self.agent.parse_response(text)
+        assert result == {"commit_message": "refactor: rename foo to bar"}
+
+    def test_parse_response_raises_on_missing_commit_line(self):
+        text = "I read the code and made some changes."
+        with pytest.raises(OutputContractError) as exc_info:
+            self.agent.parse_response(text)
+        err = exc_info.value
+        assert err.agent == "refactor"
+        assert err.task == "refactor"
+        assert "COMMIT:" in err.expected
+
+    def test_parse_response_raises_on_empty_commit_message(self):
+        text = "COMMIT:   \nSome trailing text."
+        with pytest.raises(OutputContractError):
+            self.agent.parse_response(text)
+
+    def test_parse_response_raises_on_empty_response(self):
+        with pytest.raises(OutputContractError) as exc_info:
+            self.agent.parse_response("")
+        assert exc_info.value.got_preview == ""
+
+    def test_parse_response_preview_truncated_to_200_chars(self):
+        long_text = "x" * 300
+        with pytest.raises(OutputContractError) as exc_info:
+            self.agent.parse_response(long_text)
+        assert len(exc_info.value.got_preview) == 200


### PR DESCRIPTION
Closes #24

Adds the `refactor` agent: prompt files, `RefactorAgent` class extending `ConfigDrivenAgent`, `agents.toml` registration, and `run_agent.py` wiring.

## Acceptance criteria
- ✅ `agents/refactor_agent.py` exists with `RefactorAgent` extending `ConfigDrivenAgent`
- ✅ `parse_response` extracts `COMMIT:` line and raises `OutputContractError` on failure (7 unit tests, all pass)
- ✅ `defaults/prompts/refactor/refactor.md` and `fix-review.md` created
- ✅ `[agents.refactor]` registered in `defaults/agents.toml`
- ✅ `scripts/run_agent.py` routes `refactor` to `RefactorAgent`
- ⏳ `python scripts/run_agent.py refactor refactor --input some-refactor-request.txt` produces a commit — requires human validation

Generated with [Claude Code](https://claude.ai/code)