### PR TITLE
Task 5.4: Add security-auditor agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Populated by the orchestrator or individual agents at runtime. They come from th
 | `{{inline_findings}}` | `coder_agent.py` | Formatted list of low-effort inline review fixes the coder must apply immediately in the current PR. Used by `coder/fix-inline.md`. |
 | `{{brief}}` | `scripts/run_agent.py` | Product brief text passed as `--input` to `product-planner draft-prd`. Used by `product-planner/draft-prd.md`. |
 | `{{prd}}` | `scripts/run_agent.py` | Full PRD text passed as `--input` to `product-planner propose-issues`. Used by `product-planner/propose-issues.md`. |
-| `{{input}}` | `scripts/run_agent.py` | Generic input text passed as `--input` for tasks not listed in `_TASK_INPUT_VARS` (e.g. `triager triage`). Used by `triager/triage.md`. |
+| `{{input}}` | `scripts/run_agent.py` | Generic input text passed as `--input` for tasks not listed in `_TASK_INPUT_VARS` (e.g. `triager triage`). Used by `triager/triage.md`, `security-auditor/audit.md`. |
 
 ### Adding a new variable
 

--- a/agents/security_auditor_agent.py
+++ b/agents/security_auditor_agent.py
@@ -1,0 +1,48 @@
+import json
+import re
+
+from agents.base_agent import OutputContractError
+from agents.config_driven_agent import ConfigDrivenAgent
+
+_REQUIRED_KEYS = {"findings", "summary"}
+
+
+class SecurityAuditorAgent(ConfigDrivenAgent):
+    def __init__(self):
+        super().__init__("security-auditor")
+
+    def parse_response(self, text: str) -> dict:
+        """Extract JSON {findings, summary} from Claude output.
+
+        Tries direct JSON parse, then markdown-fence-stripped parse, then a
+        brace-scan. Raises OutputContractError if none succeed or required
+        keys are missing.
+        """
+        cleaned = text.strip()
+        if cleaned.startswith("```"):
+            lines = cleaned.split("\n")
+            inner = lines[1:-1] if lines[-1].strip() == "```" else lines[1:]
+            cleaned = "\n".join(inner).strip()
+
+        candidates = [cleaned]
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        if match:
+            candidates.append(match.group())
+
+        for candidate in candidates:
+            try:
+                parsed = json.loads(candidate)
+                if isinstance(parsed, dict) and _REQUIRED_KEYS.issubset(parsed):
+                    return {
+                        "findings": parsed["findings"],
+                        "summary": parsed["summary"],
+                    }
+            except json.JSONDecodeError:
+                pass
+
+        raise OutputContractError(
+            agent="security-auditor",
+            task="audit",
+            expected="JSON object with keys: findings, summary",
+            got_preview=text[:200],
+        )

--- a/defaults/agents.toml
+++ b/defaults/agents.toml
@@ -56,3 +56,9 @@ identity = "You are a triage agent that reads failing CI logs and bug reports, c
 model = "claude-sonnet-4-6"
 tools = ["Read", "Bash"]
 tasks = ["triage"]
+
+[agents."security-auditor"]
+identity = "You are a security audit agent that scans code diffs for vulnerabilities including leaked secrets, injection flaws, and other security issues."
+model = "claude-sonnet-4-6"
+tools = ["Read", "Bash"]
+tasks = ["audit"]

--- a/defaults/prompts/security-auditor/audit.md
+++ b/defaults/prompts/security-auditor/audit.md
@@ -1,0 +1,46 @@
+You are a security audit agent. Your task is to scan the provided code diff for security vulnerabilities and report findings as structured JSON.
+
+Focus exclusively on security issues — do not report style, performance, or general correctness problems unless they have a direct security impact.
+
+Categories to look for:
+- **leaked-secret**: Hardcoded API keys, tokens, passwords, private keys, or any credential embedded in code
+- **sql-injection**: Unsanitised user input concatenated into SQL queries
+- **command-injection**: User input passed unsanitised to shell commands (subprocess, exec, eval, etc.)
+- **xss**: Unsanitised user input rendered as HTML or injected into DOM/templates
+- **path-traversal**: User-controlled file paths that could escape the intended directory
+- **hardcoded-credential**: Hardcoded usernames, passwords, or connection strings
+- **insecure-deserialization**: Use of `pickle`, `yaml.load`, or similar without safe loaders on untrusted data
+- **other**: Any other security issue not covered above (describe clearly in `body`)
+
+Diff to audit:
+{{input}}
+
+<!-- ORCHESTRATOR OUTPUT CONTRACT — DO NOT MODIFY -->
+
+Respond ONLY with a valid JSON object in this exact format — no preamble, no markdown:
+
+{
+  "findings": [
+    {
+      "severity": "CRITICAL" | "HIGH" | "MEDIUM" | "LOW",
+      "category": "leaked-secret" | "sql-injection" | "command-injection" | "xss" | "path-traversal" | "hardcoded-credential" | "insecure-deserialization" | "other",
+      "effort": "low" | "high",
+      "fix_inline": true | false,
+      "title": "Short title suitable for a GitHub issue",
+      "body": "Detailed description of the vulnerability and suggested remediation",
+      "file": "path/to/file.ext or null",
+      "line": 42 or null
+    }
+  ],
+  "summary": "One or two sentence overall security assessment"
+}
+
+Severity guidance:
+- CRITICAL: Immediately exploitable with high impact (e.g. leaked production secret, unauthenticated RCE)
+- HIGH: Exploitable under realistic conditions (e.g. SQL injection requiring authenticated access)
+- MEDIUM: Requires unusual conditions or has limited impact
+- LOW: Defence-in-depth issue, best practice violation, or minor exposure
+
+Set fix_inline to true when BOTH are true: severity is MEDIUM or LOW, and effort is low.
+
+If there are no security findings, return an empty findings array.

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -28,6 +28,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 _AGENT_CLASSES: dict[str, str] = {
     "product-planner": "agents.product_planner_agent.ProductPlannerAgent",
     "refactor": "agents.refactor_agent.RefactorAgent",
+    "security-auditor": "agents.security_auditor_agent.SecurityAuditorAgent",
     "triager": "agents.triager_agent.TriagerAgent",
 }
 

--- a/tests/test_security_auditor_agent.py
+++ b/tests/test_security_auditor_agent.py
@@ -1,0 +1,80 @@
+"""Unit tests for SecurityAuditorAgent.parse_response."""
+import json
+
+import pytest
+from agents.security_auditor_agent import SecurityAuditorAgent
+from agents.base_agent import OutputContractError
+
+
+_VALID_FINDING = {
+    "severity": "CRITICAL",
+    "category": "leaked-secret",
+    "effort": "low",
+    "fix_inline": False,
+    "title": "Hardcoded API key in config.py",
+    "body": "Line 12 contains a hardcoded API key. Move it to an environment variable.",
+    "file": "config.py",
+    "line": 12,
+}
+
+_VALID_PAYLOAD = {
+    "findings": [_VALID_FINDING],
+    "summary": "One critical finding: hardcoded secret.",
+}
+
+_VALID_JSON = json.dumps(_VALID_PAYLOAD)
+
+
+class TestParseResponse:
+    def setup_method(self):
+        self.agent = SecurityAuditorAgent()
+
+    def test_returns_findings_and_summary_on_plain_json(self):
+        result = self.agent.parse_response(_VALID_JSON)
+        assert result["summary"] == "One critical finding: hardcoded secret."
+        assert len(result["findings"]) == 1
+        assert result["findings"][0]["category"] == "leaked-secret"
+
+    def test_returns_empty_findings_when_no_issues(self):
+        payload = {"findings": [], "summary": "No security issues found."}
+        result = self.agent.parse_response(json.dumps(payload))
+        assert result["findings"] == []
+        assert result["summary"] == "No security issues found."
+
+    def test_parses_json_wrapped_in_markdown_fences(self):
+        raw = f"```json\n{_VALID_JSON}\n```"
+        result = self.agent.parse_response(raw)
+        assert result["summary"] == "One critical finding: hardcoded secret."
+
+    def test_parses_json_preceded_by_prose(self):
+        raw = f"Here is my security audit:\n\n{_VALID_JSON}"
+        result = self.agent.parse_response(raw)
+        assert len(result["findings"]) == 1
+
+    def test_raises_output_contract_error_on_plain_text(self):
+        with pytest.raises(OutputContractError) as exc_info:
+            self.agent.parse_response("No issues found in this diff.")
+        err = exc_info.value
+        assert err.agent == "security-auditor"
+        assert err.task == "audit"
+
+    def test_raises_output_contract_error_on_missing_findings_key(self):
+        payload = {"summary": "All good."}
+        with pytest.raises(OutputContractError):
+            self.agent.parse_response(json.dumps(payload))
+
+    def test_raises_output_contract_error_on_missing_summary_key(self):
+        payload = {"findings": []}
+        with pytest.raises(OutputContractError):
+            self.agent.parse_response(json.dumps(payload))
+
+    def test_raises_output_contract_error_on_empty_string(self):
+        with pytest.raises(OutputContractError) as exc_info:
+            self.agent.parse_response("")
+        assert exc_info.value.got_preview == ""
+
+    def test_got_preview_truncated_to_200_chars(self):
+        long_text = "x" * 300
+        with pytest.raises(OutputContractError) as exc_info:
+            self.agent.parse_response(long_text)
+        assert len(exc_info.value.got_preview) == 200


### PR DESCRIPTION
Closes #25

Adds the `security-auditor` agent that scans diffs for leaked secrets, injection flaws, and other security vulnerabilities.

## Acceptance criteria

- ✅ `security-auditor` registered in `scripts/run_agent.py` — `python scripts/run_agent.py security-auditor audit --input some-diff.txt` is wired up and returns parseable findings JSON
- ⚳ Live end-to-end run against a real diff — requires human validation

Generated with [Claude Code](https://claude.ai/code)