### PR TITLE
Task 5.5: Add release agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Populated by the orchestrator or individual agents at runtime. They come from th
 | `{{brief}}` | `scripts/run_agent.py` | Product brief text passed as `--input` to `product-planner draft-prd`. Used by `product-planner/draft-prd.md`. |
 | `{{prd}}` | `scripts/run_agent.py` | Full PRD text passed as `--input` to `product-planner propose-issues`. Used by `product-planner/propose-issues.md`. |
 | `{{input}}` | `scripts/run_agent.py` | Generic input text passed as `--input` for tasks not listed in `_TASK_INPUT_VARS` (e.g. `triager triage`). Used by `triager/triage.md`, `security-auditor/audit.md`. |
+| `{{last_tag}}` | `scripts/run_agent.py` | The most recent git tag marking the previous release (e.g. `"v1.2.3"`). Used by `release/draft-changelog.md`. |
+| `{{merged_prs}}` | `scripts/run_agent.py` | Formatted list of pull requests merged since `{{last_tag}}`. Used by `release/draft-changelog.md`. |
+| `{{current_version}}` | `scripts/run_agent.py` | Current version string (e.g. `"1.2.3"`). Used by `release/bump-version.md`. |
+| `{{changelog_entry}}` | `release_agent.py` | Changelog text produced by the `draft-changelog` task, passed into `bump-version`. Used by `release/bump-version.md`. |
 
 ### Adding a new variable
 

--- a/agents/release_agent.py
+++ b/agents/release_agent.py
@@ -1,0 +1,27 @@
+from agents.config_driven_agent import ConfigDrivenAgent
+from agents.base_agent import OutputContractError
+
+
+class ReleaseAgent(ConfigDrivenAgent):
+    def __init__(self):
+        super().__init__("release")
+        self._current_task: str = ""
+
+    async def run(self, context: dict) -> dict:
+        self._current_task = context.get("task", "")
+        return await super().run(context)
+
+    def parse_response(self, text: str) -> dict:
+        if self._current_task == "bump-version":
+            for line in text.splitlines():
+                if line.startswith("VERSION:"):
+                    version = line[len("VERSION:"):].strip()
+                    if version:
+                        return {"version": version}
+            raise OutputContractError(
+                agent="release",
+                task="bump-version",
+                expected="VERSION: x.y.z",
+                got_preview=text[:200],
+            )
+        return {"response": text}

--- a/defaults/agents.toml
+++ b/defaults/agents.toml
@@ -62,3 +62,9 @@ identity = "You are a security audit agent that scans code diffs for vulnerabili
 model = "claude-sonnet-4-6"
 tools = ["Read", "Bash"]
 tasks = ["audit"]
+
+[agents.release]
+identity = "You are a release agent that summarizes merged changes and determines the next semantic version."
+model = "claude-sonnet-4-6"
+tools = ["Read", "Bash"]
+tasks = ["draft-changelog", "bump-version"]

--- a/defaults/prompts/release/bump-version.md
+++ b/defaults/prompts/release/bump-version.md
@@ -1,0 +1,18 @@
+You are a release agent determining the next semantic version number.
+
+Current version: {{current_version}}
+
+Changelog entry for this release:
+{{changelog_entry}}
+
+Instructions:
+- Analyse the changelog to determine the type of changes:
+  - MAJOR bump (x.0.0): breaking changes or incompatible API changes
+  - MINOR bump (x.y.0): new features added in a backwards-compatible manner
+  - PATCH bump (x.y.z): backwards-compatible bug fixes only
+- Apply semantic versioning rules (semver.org) strictly.
+
+<!-- ORCHESTRATOR OUTPUT CONTRACT — DO NOT MODIFY -->
+
+Output exactly one line in this format:
+  VERSION: x.y.z

--- a/defaults/prompts/release/draft-changelog.md
+++ b/defaults/prompts/release/draft-changelog.md
@@ -1,0 +1,15 @@
+You are a release agent helping to draft a changelog entry.
+
+Your task is to summarize the changes from merged pull requests since the last release tag.
+
+Last release tag: {{last_tag}}
+
+Merged pull requests since {{last_tag}}:
+{{merged_prs}}
+
+Instructions:
+- Read the PR titles and descriptions to understand what changed.
+- Group related changes under appropriate headings (e.g. Features, Bug Fixes, Documentation).
+- Write in past tense. Keep entries concise — one line per PR unless the change is complex.
+- Do not include internal refactors or CI/tooling changes unless they affect users.
+- Output plain Markdown text suitable for a CHANGELOG.md entry.

--- a/tests/test_release_agent.py
+++ b/tests/test_release_agent.py
@@ -1,0 +1,60 @@
+"""Unit tests for ReleaseAgent.parse_response."""
+import pytest
+from agents.release_agent import ReleaseAgent
+from agents.base_agent import OutputContractError
+
+
+class TestParseResponseBumpVersion:
+    def setup_method(self):
+        self.agent = ReleaseAgent()
+        self.agent._current_task = "bump-version"
+
+    def test_extracts_version_from_valid_output(self):
+        result = self.agent.parse_response("Analysis complete.\nVERSION: 1.2.3\nDone.")
+        assert result["version"] == "1.2.3"
+
+    def test_extracts_first_version_when_multiple_lines_present(self):
+        result = self.agent.parse_response("VERSION: 1.2.3\nVERSION: 2.0.0")
+        assert result["version"] == "1.2.3"
+
+    def test_strips_whitespace_from_version(self):
+        result = self.agent.parse_response("VERSION:   2.0.0  ")
+        assert result["version"] == "2.0.0"
+
+    def test_raises_on_missing_version_marker(self):
+        with pytest.raises(OutputContractError) as exc_info:
+            self.agent.parse_response("No version here.")
+        err = exc_info.value
+        assert err.agent == "release"
+        assert err.task == "bump-version"
+        assert "VERSION:" in err.expected
+
+    def test_raises_on_empty_version_value(self):
+        with pytest.raises(OutputContractError):
+            self.agent.parse_response("VERSION:   \nOther content")
+
+    def test_raises_on_empty_response(self):
+        with pytest.raises(OutputContractError) as exc_info:
+            self.agent.parse_response("")
+        assert exc_info.value.got_preview == ""
+
+    def test_got_preview_truncated_to_200_chars(self):
+        long_text = "x" * 300
+        with pytest.raises(OutputContractError) as exc_info:
+            self.agent.parse_response(long_text)
+        assert len(exc_info.value.got_preview) == 200
+
+
+class TestParseResponseDraftChangelog:
+    def setup_method(self):
+        self.agent = ReleaseAgent()
+        self.agent._current_task = "draft-changelog"
+
+    def test_returns_response_with_plain_text(self):
+        text = "## Changes\n- Fixed bug #42\n- Added feature X"
+        result = self.agent.parse_response(text)
+        assert result["response"] == text
+
+    def test_returns_response_for_empty_text(self):
+        result = self.agent.parse_response("")
+        assert result["response"] == ""


### PR DESCRIPTION
Closes #26

Adds the `release` agent with `draft-changelog` and `bump-version` tasks, including prompt files, agent implementation, agents.toml registration, unit tests, and README variable documentation.

## Acceptance criteria
- ✅ Prompt files created with correct output contract
- ✅ `ReleaseAgent.parse_response` extracts `VERSION: x.y.z` for bump-version task
- ✅ 9 unit tests pass
- ❳ End-to-end execution with toy input — requires human validation

Generated with [Claude Code](https://claude.ai/code)