### PR TITLE
Task 6.1: Add Spades target-repo config files

### DIFF
--- a/examples/spades-target/.agents.md
+++ b/examples/spades-target/.agents.md
@@ -1,0 +1,27 @@
+## @shared
+
+Spades Online is a card game backend built with Node.js and ES Modules.
+
+- Game logic lives in `server/game/` — this is the core domain code.
+- The server layer (routes, socket handlers, etc.) lives in `server/`.
+- Never modify `.gitignore`.
+- Never run `npm install` — dependencies are pre-installed in the repo environment.
+- Use ES Modules (`import`/`export`) throughout. All local import paths require the `.js` extension (e.g. `'./game.js'`, not `'./game'`).
+- Tests use the Node.js built-in `node:test` runner. Import with `import { test, describe } from 'node:test'` and `import assert from 'node:assert/strict'`.
+
+## @reviewer
+
+In addition to the standard review criteria, watch for these Spades-specific issues:
+
+- **Missing `.js` extension on local imports** — Node.js ES Modules require explicit extensions; bare imports will throw at runtime.
+- **`require()` calls** — this project is ES Modules only. Flag any CommonJS `require()` or `module.exports`.
+- **Game-state mutation across sessions** — game state is per-room; mutations must not bleed across concurrent games.
+- **Synchronous I/O or blocking operations** in async game handlers — these will stall the event loop and affect all connected players.
+- **Unhandled promise rejections** in socket event handlers — always `await` or `.catch()`.
+
+## @tester
+
+- Test files go in `test/` following the `test/**/*.test.js` pattern.
+- Use `node:test` and `node:assert/strict` — do not install or import jest, mocha, or other frameworks.
+- Each test file must be independently runnable with `node --test <file>`.
+- When testing game logic in `server/game/`, import the module directly and test pure functions in isolation where possible.

--- a/examples/spades-target/agents.toml
+++ b/examples/spades-target/agents.toml
@@ -1,0 +1,18 @@
+# Spades Online — target-repo config for the general orchestrator.
+#
+# Copy this file to the root of the Spades repo (i.e. spades/agents.toml).
+# The orchestrator loads agents.toml from the target-repo root; this [conventions]
+# block replaces the orchestrator's defaults entirely.
+#
+# Per-agent [agents.*] overrides are not required for v1 — defaults are sufficient.
+# Add an [agents.coder] etc. block here only if Spades needs a model or tool change.
+
+[conventions]
+primary_language = "javascript"
+codebase_layout_hint = "server/game/ for game logic, server/ for API and socket handlers, test/ for tests"
+test_file_pattern = "test/**/*.test.js"
+test_file_extension = "js"
+test_runner = "node:test (built-in — use: import { test, describe } from 'node:test'; import assert from 'node:assert/strict';)"
+test_command = "node --test"
+install_command = "npm install"
+module_system_hint = "ES Modules — use import/export syntax. Never use require(). All local import paths must include the .js extension (e.g. './game.js' not './game')."


### PR DESCRIPTION
Closes #28

Adds `examples/spades-target/` with the three config files the Spades repo needs to work with the generalized orchestrator. Copy these to the Spades repo root at cutover.

## Acceptance criteria
- ✅ `ls examples/spades-target/` shows `agents.toml`, `prompts/`, `.agents.md`
- ❳ Orchestrator can be pointed at Spades (requires human validation against live repo)

Generated with [Claude Code](https://claude.ai/code)