### PR TITLE
fix: feed OutputContractError reason back to docs agent on retry

### DIFF
--- a/agents/documentation_agent.py
+++ b/agents/documentation_agent.py
@@ -62,10 +62,28 @@ class DocumentationAgent(BaseAgent):
             "docs-writer", "document", context, registry, _ORCHESTRATOR_ROOT, _TARGET_ROOT
         )
 
-        # Claude Code runs in REPO_DIR so it can read and write doc files directly
-        response = run_claude(prompt, allowed_tools="Read,Edit,Bash", model="claude-sonnet-4-6")
-
-        parsed = self.parse_response(response)
+        # Claude Code runs in REPO_DIR so it can read and write doc files directly.
+        # Retry up to 3 times on OutputContractError, feeding the error back so
+        # Claude understands what format is required.
+        MAX_FORMAT_RETRIES = 3
+        current_prompt = prompt
+        for attempt in range(1, MAX_FORMAT_RETRIES + 1):
+            response = run_claude(current_prompt, allowed_tools="Read,Edit,Bash", model="claude-sonnet-4-6")
+            try:
+                parsed = self.parse_response(response)
+                break
+            except OutputContractError as e:
+                if attempt == MAX_FORMAT_RETRIES:
+                    raise
+                print(f"[Docs] OutputContractError on attempt {attempt}/{MAX_FORMAT_RETRIES}: {e}")
+                current_prompt = (
+                    prompt
+                    + f"\n\n---\n**Previous attempt failed the output contract.**\n"
+                    f"Error: {e}\n"
+                    f"Your last response was:\n```\n{response[:500]}\n```\n"
+                    f"Please re-read the output contract at the bottom of this prompt "
+                    f"and respond with ONLY `NO_CHANGES` or one or more `UPDATED: <path>` lines."
+                )
         files_updated = parsed["files_updated"]
 
         if not files_updated:


### PR DESCRIPTION
Closes #68

Previously, an OutputContractError in DocumentationAgent propagated to the orchestrator, which retried from checkpoint with the same prompt. Claude had no feedback about the failure, so it repeated the same bad output until TRANSIENT_MAX_RETRIES was exhausted.

The fix adds an internal retry loop (up to 3 attempts) inside `DocumentationAgent.run()` that appends the error message and previous bad response to the prompt on retry, so Claude can correct its output format.

Generated with [Claude Code](https://claude.ai/code)